### PR TITLE
Don't allow changing PK columns, fully implement TruncateTable request

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ TEST_ARGS=--input-file=input_all_data_types.json make sdk-test
 Run the SDK tester with all input JSON files (see [sdk_tests](./sdk_tests) directory):
 
 ```bash
-make sdk-test
+make recreate-test-db && make sdk-test
 ```
 
 See also: Fivetran SDK

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ Run the SDK tester with a particular input file from [sdk_tests](./sdk_tests) di
 for example, `input_all_data_types.json`:
 
 ```bash
-TEST_ARGS=--input-file=input_all_data_types.json make sdk-test
+make recreate-test-db && TEST_ARGS=--input-file=input_all_data_types.json make sdk-test
 ```
 
 Run the SDK tester with all input JSON files (see [sdk_tests](./sdk_tests) directory):

--- a/Makefile
+++ b/Makefile
@@ -24,14 +24,16 @@ generate-proto:
         destination_sdk.proto
 
 sdk-test:
-	curl --data-binary "DROP DATABASE IF EXISTS tester" http://localhost:8123
-	curl --data-binary "CREATE DATABASE tester" http://localhost:8123
 	docker run --mount type=bind,source=$$PWD/sdk_tests,target=/data \
 		-a STDIN -a STDOUT -a STDERR \
 		-e WORKING_DIR=$$PWD/sdk_tests \
 		-e GRPC_HOSTNAME=172.17.0.1 \
 		--network=host \
 		fivetrandocker/sdk-destination-tester:024.0213.001 $$TEST_ARGS
+
+recreate-test-db:
+	curl --data-binary "DROP DATABASE IF EXISTS tester" http://localhost:8123
+	curl --data-binary "CREATE DATABASE tester" http://localhost:8123
 
 lint:
 	docker run --rm -v $$PWD:/destination -w /destination golangci/golangci-lint:v1.55.2 golangci-lint run -v

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ The destination app will create a ClickHouse table
 using [ReplacingMergeTree](https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/replacingmergetree)
 engine versioned by `_fivetran_synced` column.
 
-Every column except primary (ordering) keys and Fivetran metadata columns will be created as `Nullable(T)`, where `T` is a
+Every column except primary (ordering) keys and Fivetran metadata columns will be created
+as [Nullable(T)](https://clickhouse.com/docs/en/sql-reference/data-types/nullable), where `T` is a
 ClickHouse type based on the [data types mapping](#data-types-mapping).
 
 ### Single primary key in the source table

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@
 for [Fivetran](https://fivetran.com) automated data movement platform, based on
 the [Fivetran Partner SDK](https://github.com/fivetran/fivetran_sdk).
 
+## Supported platforms
+
+Currently, supports [ClickHouse Cloud](https://clickhouse.cloud) only.
+
 ## Data types mapping
 
 | Fivetran type  | ClickHouse type                                                                            |
@@ -41,13 +45,14 @@ the original data type. [JSON](https://clickhouse.com/docs/en/sql-reference/data
 is still marked as experimental and not production
 ready.
 
-NB: every column except primary keys and Fivetran metadata columns will be created as `Nullable(T)`.
-
 ## Destination table
 
 The destination app will create a ClickHouse table
 using [ReplacingMergeTree](https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/replacingmergetree)
 engine versioned by `_fivetran_synced` column.
+
+Every column except primary (ordering) keys and Fivetran metadata columns will be created as `Nullable(T)`, where `T` is a
+ClickHouse type based on the [data types mapping](#data-types-mapping).
 
 ### Single primary key in the source table
 

--- a/destination/common/flags/flags.go
+++ b/destination/common/flags/flags.go
@@ -1,6 +1,9 @@
 package flags
 
-import "flag"
+import (
+	"flag"
+	"time"
+)
 
 var Port = flag.Uint("port", 50052,
 	"Listen port")
@@ -21,6 +24,8 @@ var MaxIdleConnections = flag.Uint("max-idle-connections", 5,
 	"Max number of idle connections for ClickHouse client")
 var MaxOpenConnections = flag.Uint("max-open-connections", 10,
 	"Max number of open connections for ClickHouse client (recommended: max-idle-connections + 5)")
+var RequestTimeoutDuration = flag.Duration("request-timeout-duration", 300*time.Second,
+	"Timeout for ClickHouse client requests")
 
 var MaxRetries = flag.Uint("max-retries", 10,
 	"Max number of retries for ClickHouse client in case of network errors")

--- a/destination/common/types/types.go
+++ b/destination/common/types/types.go
@@ -28,6 +28,18 @@ type PrimaryKeyColumn struct {
 	Type  pb.DataType
 }
 
+// PrimaryKeysAndMetadataColumns
+// In all CSV files, fivetran_sdk.Table column index = CSV column index.
+// PrimaryKeys are used when generating select queries, see sql.GetSelectByPrimaryKeysQuery.
+// also used for generating mapping keys, see db.GetCSVRowMappingKey and db.GetDatabaseRowMappingKey.
+// FivetranSyncedIdx index of the _fivetran_synced column in fivetran_sdk.Table (see db.ToSoftDeletedRow)
+// FivetranDeletedIdx index of the _fivetran_deleted column in fivetran_sdk.Table (see db.ToSoftDeletedRow)
+type PrimaryKeysAndMetadataColumns struct {
+	PrimaryKeys        []*PrimaryKeyColumn
+	FivetranSyncedIdx  uint
+	FivetranDeletedIdx uint
+}
+
 type AlterTableOpType int
 
 const (

--- a/destination/db/alter_table_ops.go
+++ b/destination/db/alter_table_ops.go
@@ -16,15 +16,20 @@ func GetAlterTableOps(from *types.TableDescription, to *types.TableDescription) 
 	for _, toCol := range to.Columns {
 		fromCol, ok := from.Mapping[toCol.Name]
 		if !ok {
+			if toCol.IsPrimaryKey {
+				return nil, fmt.Errorf("primary key columns cannot be added")
+			}
 			ops = append(ops, &types.AlterTableOp{
 				Op:      types.AlterTableAdd,
 				Column:  toCol.Name,
 				Type:    &toCol.Type,
 				Comment: &toCol.Comment,
 			})
+		} else if fromCol.IsPrimaryKey != toCol.IsPrimaryKey {
+			return nil, fmt.Errorf("primary key columns cannot be modified")
 		} else if fromCol.Type != toCol.Type || fromCol.Comment != toCol.Comment {
 			if fromCol.IsPrimaryKey {
-				return nil, fmt.Errorf("primary key columns cannot be changed")
+				return nil, fmt.Errorf("primary key columns types cannot be changed")
 			}
 			ops = append(ops, &types.AlterTableOp{
 				Op:      types.AlterTableModify,

--- a/destination/db/alter_table_ops_test.go
+++ b/destination/db/alter_table_ops_test.go
@@ -14,7 +14,7 @@ func TestGetAlterTableOpsModify(t *testing.T) {
 	curCol2 := &types.ColumnDefinition{Name: "qux", Type: "String", IsPrimaryKey: false}
 	alterCol1 := &types.ColumnDefinition{Name: "qaz", Type: "Int32", IsPrimaryKey: true}
 	alterCol2 := &types.ColumnDefinition{Name: "qux", Type: "Int64", IsPrimaryKey: false}
-	ops := GetAlterTableOps(
+	ops, err := GetAlterTableOps(
 		&types.TableDescription{
 			Mapping: map[string]*types.ColumnDefinition{"qaz": curCol1, "qux": curCol2},
 			Columns: []*types.ColumnDefinition{curCol1, curCol2},
@@ -23,6 +23,7 @@ func TestGetAlterTableOpsModify(t *testing.T) {
 			Mapping: map[string]*types.ColumnDefinition{"qaz": alterCol1, "qux": alterCol2},
 			Columns: []*types.ColumnDefinition{alterCol1, alterCol2},
 		})
+	assert.NoError(t, err)
 	assert.Equal(t, ops, []*types.AlterTableOp{{Op: types.AlterTableModify, Column: "qux", Type: &int64Type, Comment: &emptyComment}})
 }
 
@@ -34,7 +35,7 @@ func TestGetAlterTableOpsAdd(t *testing.T) {
 	alterCol1 := &types.ColumnDefinition{Name: "qaz", Type: "Int32", IsPrimaryKey: true}
 	alterCol2 := &types.ColumnDefinition{Name: "qux", Type: "String", IsPrimaryKey: false}
 	alterCol3 := &types.ColumnDefinition{Name: "zaq", Type: "Int64", IsPrimaryKey: false}
-	ops := GetAlterTableOps(
+	ops, err := GetAlterTableOps(
 		&types.TableDescription{
 			Mapping: map[string]*types.ColumnDefinition{"qaz": curCol1, "qux": curCol2},
 			Columns: []*types.ColumnDefinition{curCol1, curCol2},
@@ -43,6 +44,7 @@ func TestGetAlterTableOpsAdd(t *testing.T) {
 			Mapping: map[string]*types.ColumnDefinition{"qaz": alterCol1, "qux": alterCol2, "zaq": alterCol3},
 			Columns: []*types.ColumnDefinition{alterCol1, alterCol2, alterCol3},
 		})
+	assert.NoError(t, err)
 	assert.Equal(t, ops, []*types.AlterTableOp{{Op: types.AlterTableAdd, Column: "zaq", Type: &int64Type, Comment: &emptyComment}})
 
 }
@@ -51,7 +53,7 @@ func TestGetAlterTableOpsDrop(t *testing.T) {
 	curCol1 := &types.ColumnDefinition{Name: "qaz", Type: "Int32", IsPrimaryKey: true}
 	curCol2 := &types.ColumnDefinition{Name: "qux", Type: "String", IsPrimaryKey: false}
 	alterCol1 := &types.ColumnDefinition{Name: "qaz", Type: "Int32", IsPrimaryKey: true}
-	ops := GetAlterTableOps(
+	ops, err := GetAlterTableOps(
 		&types.TableDescription{
 			Mapping: map[string]*types.ColumnDefinition{"qaz": curCol1, "qux": curCol2},
 			Columns: []*types.ColumnDefinition{curCol1, curCol2},
@@ -60,6 +62,7 @@ func TestGetAlterTableOpsDrop(t *testing.T) {
 			Mapping: map[string]*types.ColumnDefinition{"qaz": alterCol1},
 			Columns: []*types.ColumnDefinition{alterCol1},
 		})
+	assert.NoError(t, err)
 	assert.Equal(t, ops, []*types.AlterTableOp{{Op: types.AlterTableDrop, Column: "qux", Type: nil, Comment: nil}})
 }
 
@@ -67,11 +70,11 @@ func TestGetAlterTableOpsCombined(t *testing.T) {
 	int64Type := "Int64"
 	int16Type := "Int16"
 	emptyComment := ""
-	curCol1 := &types.ColumnDefinition{Name: "qaz", Type: "Int32", IsPrimaryKey: true}
+	curCol1 := &types.ColumnDefinition{Name: "qaz", Type: "Int32", IsPrimaryKey: false}
 	curCol2 := &types.ColumnDefinition{Name: "qux", Type: "String", IsPrimaryKey: false}
 	alterCol1 := &types.ColumnDefinition{Name: "qux", Type: "Int64", IsPrimaryKey: false}
 	alterCol2 := &types.ColumnDefinition{Name: "zaq", Type: "Int16", IsPrimaryKey: false}
-	ops := GetAlterTableOps(
+	ops, err := GetAlterTableOps(
 		&types.TableDescription{
 			Mapping: map[string]*types.ColumnDefinition{"qaz": curCol1, "qux": curCol2},
 			Columns: []*types.ColumnDefinition{curCol1, curCol2},
@@ -80,6 +83,7 @@ func TestGetAlterTableOpsCombined(t *testing.T) {
 			Mapping: map[string]*types.ColumnDefinition{"qux": alterCol1, "zaq": alterCol2},
 			Columns: []*types.ColumnDefinition{alterCol1, alterCol2},
 		})
+	assert.NoError(t, err)
 	assert.Equal(t, ops, []*types.AlterTableOp{
 		{Op: types.AlterTableModify, Column: "qux", Type: &int64Type, Comment: &emptyComment},
 		{Op: types.AlterTableAdd, Column: "zaq", Type: &int16Type, Comment: &emptyComment},
@@ -101,7 +105,8 @@ func TestGetAlterTableOpsEqualTables(t *testing.T) {
 		Mapping: map[string]*types.ColumnDefinition{"qaz": alterCol1, "qux": alterCol2},
 		Columns: []*types.ColumnDefinition{alterCol1, alterCol2},
 	}
-	ops := GetAlterTableOps(td1, td2)
+	ops, err := GetAlterTableOps(td1, td2)
+	assert.NoError(t, err)
 	assert.Equal(t, ops, []*types.AlterTableOp{})
 }
 
@@ -122,7 +127,7 @@ func TestGetAlterTableOpsWithComments(t *testing.T) {
 	alterCol5 := &types.ColumnDefinition{Name: "s10", Type: strType, IsPrimaryKey: false, Comment: emptyComment}
 	alterCol6 := &types.ColumnDefinition{Name: "s11", Type: strType, IsPrimaryKey: false, Comment: binaryComment}
 	alterCol7 := &types.ColumnDefinition{Name: "s12", Type: strType, IsPrimaryKey: false, Comment: xmlComment}
-	ops := GetAlterTableOps(
+	ops, err := GetAlterTableOps(
 		&types.TableDescription{
 			Mapping: map[string]*types.ColumnDefinition{
 				"s1": curCol1, "s2": curCol2, "s3": curCol3, "s4": curCol4, "s5": curCol5,
@@ -136,6 +141,7 @@ func TestGetAlterTableOpsWithComments(t *testing.T) {
 			},
 			Columns: []*types.ColumnDefinition{alterCol1, alterCol2, alterCol3, alterCol4, alterCol5, alterCol6, alterCol7},
 		})
+	assert.NoError(t, err)
 	assert.Equal(t, ops, []*types.AlterTableOp{
 		{Op: types.AlterTableModify, Column: "s1", Type: &strType, Comment: &binaryComment},
 		{Op: types.AlterTableModify, Column: "s2", Type: &strType, Comment: &xmlComment},
@@ -146,4 +152,39 @@ func TestGetAlterTableOpsWithComments(t *testing.T) {
 		{Op: types.AlterTableAdd, Column: "s12", Type: &strType, Comment: &xmlComment},
 		{Op: types.AlterTableDrop, Column: "s5", Type: nil, Comment: nil},
 	})
+}
+
+func TestGetAlterTableOpsChangePrimaryKey(t *testing.T) {
+	curCol1 := &types.ColumnDefinition{Name: "qaz", Type: "Int32", IsPrimaryKey: true}
+	curCol2 := &types.ColumnDefinition{Name: "qux", Type: "String", IsPrimaryKey: false}
+	alterCol1 := &types.ColumnDefinition{Name: "qaz", Type: "Int64", IsPrimaryKey: true}
+	alterCol2 := &types.ColumnDefinition{Name: "qux", Type: "Int64", IsPrimaryKey: false}
+	ops, err := GetAlterTableOps(
+		&types.TableDescription{
+			Mapping: map[string]*types.ColumnDefinition{"qaz": curCol1, "qux": curCol2},
+			Columns: []*types.ColumnDefinition{curCol1, curCol2},
+		},
+		&types.TableDescription{
+			Mapping: map[string]*types.ColumnDefinition{"qaz": alterCol1, "qux": alterCol2},
+			Columns: []*types.ColumnDefinition{alterCol1, alterCol2},
+		})
+	assert.ErrorContains(t, err, "primary key columns cannot be changed")
+	assert.Equal(t, ops, []*types.AlterTableOp(nil))
+}
+
+func TestGetAlterTableOpsDropPrimaryKey(t *testing.T) {
+	curCol1 := &types.ColumnDefinition{Name: "qaz", Type: "Int32", IsPrimaryKey: true}
+	curCol2 := &types.ColumnDefinition{Name: "qux", Type: "String", IsPrimaryKey: false}
+	alterCol := &types.ColumnDefinition{Name: "qux", Type: "Int64", IsPrimaryKey: false}
+	ops, err := GetAlterTableOps(
+		&types.TableDescription{
+			Mapping: map[string]*types.ColumnDefinition{"qaz": curCol1, "qux": curCol2},
+			Columns: []*types.ColumnDefinition{curCol1, curCol2},
+		},
+		&types.TableDescription{
+			Mapping: map[string]*types.ColumnDefinition{"qux": alterCol},
+			Columns: []*types.ColumnDefinition{alterCol},
+		})
+	assert.ErrorContains(t, err, "primary key columns cannot be dropped")
+	assert.Equal(t, ops, []*types.AlterTableOp(nil))
 }

--- a/destination/db/alter_table_ops_test.go
+++ b/destination/db/alter_table_ops_test.go
@@ -115,13 +115,13 @@ func TestGetAlterTableOpsWithComments(t *testing.T) {
 	emptyComment := ""
 	xmlComment := "XML"
 	binaryComment := "BINARY"
-	curCol1 := &types.ColumnDefinition{Name: "s1", Type: strType, IsPrimaryKey: true, Comment: emptyComment}
-	curCol2 := &types.ColumnDefinition{Name: "s2", Type: strType, IsPrimaryKey: true, Comment: emptyComment}
+	curCol1 := &types.ColumnDefinition{Name: "s1", Type: strType, IsPrimaryKey: false, Comment: emptyComment}
+	curCol2 := &types.ColumnDefinition{Name: "s2", Type: strType, IsPrimaryKey: false, Comment: emptyComment}
 	curCol3 := &types.ColumnDefinition{Name: "s3", Type: strType, IsPrimaryKey: false, Comment: xmlComment}
 	curCol4 := &types.ColumnDefinition{Name: "s4", Type: strType, IsPrimaryKey: false, Comment: binaryComment}
 	curCol5 := &types.ColumnDefinition{Name: "s5", Type: strType, IsPrimaryKey: false, Comment: emptyComment}
-	alterCol1 := &types.ColumnDefinition{Name: "s1", Type: strType, IsPrimaryKey: true, Comment: binaryComment}
-	alterCol2 := &types.ColumnDefinition{Name: "s2", Type: strType, IsPrimaryKey: true, Comment: xmlComment}
+	alterCol1 := &types.ColumnDefinition{Name: "s1", Type: strType, IsPrimaryKey: false, Comment: binaryComment}
+	alterCol2 := &types.ColumnDefinition{Name: "s2", Type: strType, IsPrimaryKey: false, Comment: xmlComment}
 	alterCol3 := &types.ColumnDefinition{Name: "s3", Type: strType, IsPrimaryKey: false, Comment: emptyComment}
 	alterCol4 := &types.ColumnDefinition{Name: "s4", Type: strType, IsPrimaryKey: false, Comment: emptyComment}
 	alterCol5 := &types.ColumnDefinition{Name: "s10", Type: strType, IsPrimaryKey: false, Comment: emptyComment}

--- a/destination/db/alter_table_ops_test.go
+++ b/destination/db/alter_table_ops_test.go
@@ -10,19 +10,15 @@ import (
 func TestGetAlterTableOpsModify(t *testing.T) {
 	int64Type := "Int64"
 	emptyComment := ""
-	curCol1 := &types.ColumnDefinition{Name: "qaz", Type: "Int32", IsPrimaryKey: true}
-	curCol2 := &types.ColumnDefinition{Name: "qux", Type: "String", IsPrimaryKey: false}
-	alterCol1 := &types.ColumnDefinition{Name: "qaz", Type: "Int32", IsPrimaryKey: true}
-	alterCol2 := &types.ColumnDefinition{Name: "qux", Type: "Int64", IsPrimaryKey: false}
 	ops, err := GetAlterTableOps(
-		&types.TableDescription{
-			Mapping: map[string]*types.ColumnDefinition{"qaz": curCol1, "qux": curCol2},
-			Columns: []*types.ColumnDefinition{curCol1, curCol2},
-		},
-		&types.TableDescription{
-			Mapping: map[string]*types.ColumnDefinition{"qaz": alterCol1, "qux": alterCol2},
-			Columns: []*types.ColumnDefinition{alterCol1, alterCol2},
-		})
+		types.MakeTableDescription([]*types.ColumnDefinition{
+			{Name: "qaz", Type: "Int32", IsPrimaryKey: true},
+			{Name: "qux", Type: "String", IsPrimaryKey: false},
+		}),
+		types.MakeTableDescription([]*types.ColumnDefinition{
+			{Name: "qaz", Type: "Int32", IsPrimaryKey: true},
+			{Name: "qux", Type: "Int64", IsPrimaryKey: false},
+		}))
 	assert.NoError(t, err)
 	assert.Equal(t, ops, []*types.AlterTableOp{{Op: types.AlterTableModify, Column: "qux", Type: &int64Type, Comment: &emptyComment}})
 }
@@ -30,59 +26,47 @@ func TestGetAlterTableOpsModify(t *testing.T) {
 func TestGetAlterTableOpsAdd(t *testing.T) {
 	int64Type := "Int64"
 	emptyComment := ""
-	curCol1 := &types.ColumnDefinition{Name: "qaz", Type: "Int32", IsPrimaryKey: true}
-	curCol2 := &types.ColumnDefinition{Name: "qux", Type: "String", IsPrimaryKey: false}
-	alterCol1 := &types.ColumnDefinition{Name: "qaz", Type: "Int32", IsPrimaryKey: true}
-	alterCol2 := &types.ColumnDefinition{Name: "qux", Type: "String", IsPrimaryKey: false}
-	alterCol3 := &types.ColumnDefinition{Name: "zaq", Type: "Int64", IsPrimaryKey: false}
 	ops, err := GetAlterTableOps(
-		&types.TableDescription{
-			Mapping: map[string]*types.ColumnDefinition{"qaz": curCol1, "qux": curCol2},
-			Columns: []*types.ColumnDefinition{curCol1, curCol2},
-		},
-		&types.TableDescription{
-			Mapping: map[string]*types.ColumnDefinition{"qaz": alterCol1, "qux": alterCol2, "zaq": alterCol3},
-			Columns: []*types.ColumnDefinition{alterCol1, alterCol2, alterCol3},
-		})
+		types.MakeTableDescription([]*types.ColumnDefinition{
+			{Name: "qaz", Type: "Int32", IsPrimaryKey: true},
+			{Name: "qux", Type: "String", IsPrimaryKey: false},
+		}),
+		types.MakeTableDescription([]*types.ColumnDefinition{
+			{Name: "qaz", Type: "Int32", IsPrimaryKey: true},
+			{Name: "qux", Type: "String", IsPrimaryKey: false},
+			{Name: "zaq", Type: "Int64", IsPrimaryKey: false},
+		}))
 	assert.NoError(t, err)
 	assert.Equal(t, ops, []*types.AlterTableOp{{Op: types.AlterTableAdd, Column: "zaq", Type: &int64Type, Comment: &emptyComment}})
 
 }
 
 func TestGetAlterTableOpsDrop(t *testing.T) {
-	curCol1 := &types.ColumnDefinition{Name: "qaz", Type: "Int32", IsPrimaryKey: true}
-	curCol2 := &types.ColumnDefinition{Name: "qux", Type: "String", IsPrimaryKey: false}
-	alterCol1 := &types.ColumnDefinition{Name: "qaz", Type: "Int32", IsPrimaryKey: true}
 	ops, err := GetAlterTableOps(
-		&types.TableDescription{
-			Mapping: map[string]*types.ColumnDefinition{"qaz": curCol1, "qux": curCol2},
-			Columns: []*types.ColumnDefinition{curCol1, curCol2},
-		},
-		&types.TableDescription{
-			Mapping: map[string]*types.ColumnDefinition{"qaz": alterCol1},
-			Columns: []*types.ColumnDefinition{alterCol1},
-		})
+		types.MakeTableDescription([]*types.ColumnDefinition{
+			{Name: "qaz", Type: "Int32", IsPrimaryKey: true},
+			{Name: "qux", Type: "String", IsPrimaryKey: false},
+		}),
+		types.MakeTableDescription([]*types.ColumnDefinition{
+			{Name: "qaz", Type: "Int32", IsPrimaryKey: true},
+		}))
 	assert.NoError(t, err)
 	assert.Equal(t, ops, []*types.AlterTableOp{{Op: types.AlterTableDrop, Column: "qux", Type: nil, Comment: nil}})
 }
 
-func TestGetAlterTableOpsCombined(t *testing.T) {
+func TestGetAlterTableOpsAllCombined(t *testing.T) {
 	int64Type := "Int64"
 	int16Type := "Int16"
 	emptyComment := ""
-	curCol1 := &types.ColumnDefinition{Name: "qaz", Type: "Int32", IsPrimaryKey: false}
-	curCol2 := &types.ColumnDefinition{Name: "qux", Type: "String", IsPrimaryKey: false}
-	alterCol1 := &types.ColumnDefinition{Name: "qux", Type: "Int64", IsPrimaryKey: false}
-	alterCol2 := &types.ColumnDefinition{Name: "zaq", Type: "Int16", IsPrimaryKey: false}
 	ops, err := GetAlterTableOps(
-		&types.TableDescription{
-			Mapping: map[string]*types.ColumnDefinition{"qaz": curCol1, "qux": curCol2},
-			Columns: []*types.ColumnDefinition{curCol1, curCol2},
-		},
-		&types.TableDescription{
-			Mapping: map[string]*types.ColumnDefinition{"qux": alterCol1, "zaq": alterCol2},
-			Columns: []*types.ColumnDefinition{alterCol1, alterCol2},
-		})
+		types.MakeTableDescription([]*types.ColumnDefinition{
+			{Name: "qaz", Type: "Int32", IsPrimaryKey: false},
+			{Name: "qux", Type: "String", IsPrimaryKey: false},
+		}),
+		types.MakeTableDescription([]*types.ColumnDefinition{
+			{Name: "qux", Type: "Int64", IsPrimaryKey: false},
+			{Name: "zaq", Type: "Int16", IsPrimaryKey: false},
+		}))
 	assert.NoError(t, err)
 	assert.Equal(t, ops, []*types.AlterTableOp{
 		{Op: types.AlterTableModify, Column: "qux", Type: &int64Type, Comment: &emptyComment},
@@ -93,19 +77,15 @@ func TestGetAlterTableOpsCombined(t *testing.T) {
 
 func TestGetAlterTableOpsEqualTables(t *testing.T) {
 	// Make sure they all are different pointers
-	curCol1 := &types.ColumnDefinition{Name: "qaz", Type: "Int32", IsPrimaryKey: true}
-	curCol2 := &types.ColumnDefinition{Name: "qux", Type: "String", IsPrimaryKey: false}
-	alterCol1 := &types.ColumnDefinition{Name: "qaz", Type: "Int32", IsPrimaryKey: true}
-	alterCol2 := &types.ColumnDefinition{Name: "qux", Type: "String", IsPrimaryKey: false}
-	td1 := &types.TableDescription{
-		Mapping: map[string]*types.ColumnDefinition{"qaz": curCol1, "qux": curCol2},
-		Columns: []*types.ColumnDefinition{curCol1, curCol2},
-	}
-	td2 := &types.TableDescription{
-		Mapping: map[string]*types.ColumnDefinition{"qaz": alterCol1, "qux": alterCol2},
-		Columns: []*types.ColumnDefinition{alterCol1, alterCol2},
-	}
-	ops, err := GetAlterTableOps(td1, td2)
+	ops, err := GetAlterTableOps(
+		types.MakeTableDescription([]*types.ColumnDefinition{
+			{Name: "qaz", Type: "Int32", IsPrimaryKey: true},
+			{Name: "qux", Type: "String", IsPrimaryKey: false},
+		}),
+		types.MakeTableDescription([]*types.ColumnDefinition{
+			{Name: "qaz", Type: "Int32", IsPrimaryKey: true},
+			{Name: "qux", Type: "String", IsPrimaryKey: false},
+		}))
 	assert.NoError(t, err)
 	assert.Equal(t, ops, []*types.AlterTableOp{})
 }
@@ -115,32 +95,23 @@ func TestGetAlterTableOpsWithComments(t *testing.T) {
 	emptyComment := ""
 	xmlComment := "XML"
 	binaryComment := "BINARY"
-	curCol1 := &types.ColumnDefinition{Name: "s1", Type: strType, IsPrimaryKey: false, Comment: emptyComment}
-	curCol2 := &types.ColumnDefinition{Name: "s2", Type: strType, IsPrimaryKey: false, Comment: emptyComment}
-	curCol3 := &types.ColumnDefinition{Name: "s3", Type: strType, IsPrimaryKey: false, Comment: xmlComment}
-	curCol4 := &types.ColumnDefinition{Name: "s4", Type: strType, IsPrimaryKey: false, Comment: binaryComment}
-	curCol5 := &types.ColumnDefinition{Name: "s5", Type: strType, IsPrimaryKey: false, Comment: emptyComment}
-	alterCol1 := &types.ColumnDefinition{Name: "s1", Type: strType, IsPrimaryKey: false, Comment: binaryComment}
-	alterCol2 := &types.ColumnDefinition{Name: "s2", Type: strType, IsPrimaryKey: false, Comment: xmlComment}
-	alterCol3 := &types.ColumnDefinition{Name: "s3", Type: strType, IsPrimaryKey: false, Comment: emptyComment}
-	alterCol4 := &types.ColumnDefinition{Name: "s4", Type: strType, IsPrimaryKey: false, Comment: emptyComment}
-	alterCol5 := &types.ColumnDefinition{Name: "s10", Type: strType, IsPrimaryKey: false, Comment: emptyComment}
-	alterCol6 := &types.ColumnDefinition{Name: "s11", Type: strType, IsPrimaryKey: false, Comment: binaryComment}
-	alterCol7 := &types.ColumnDefinition{Name: "s12", Type: strType, IsPrimaryKey: false, Comment: xmlComment}
 	ops, err := GetAlterTableOps(
-		&types.TableDescription{
-			Mapping: map[string]*types.ColumnDefinition{
-				"s1": curCol1, "s2": curCol2, "s3": curCol3, "s4": curCol4, "s5": curCol5,
-			},
-			Columns: []*types.ColumnDefinition{curCol1, curCol2, curCol3, curCol4, curCol5},
-		},
-		&types.TableDescription{
-			Mapping: map[string]*types.ColumnDefinition{
-				"s1": alterCol1, "s2": alterCol2, "s3": alterCol3, "s4": alterCol4,
-				"s10": alterCol5, "s11": alterCol6, "s12": alterCol7,
-			},
-			Columns: []*types.ColumnDefinition{alterCol1, alterCol2, alterCol3, alterCol4, alterCol5, alterCol6, alterCol7},
-		})
+		types.MakeTableDescription([]*types.ColumnDefinition{
+			{Name: "s1", Type: strType, IsPrimaryKey: false, Comment: emptyComment},
+			{Name: "s2", Type: strType, IsPrimaryKey: false, Comment: emptyComment},
+			{Name: "s3", Type: strType, IsPrimaryKey: false, Comment: xmlComment},
+			{Name: "s4", Type: strType, IsPrimaryKey: false, Comment: binaryComment},
+			{Name: "s5", Type: strType, IsPrimaryKey: false, Comment: emptyComment},
+		}),
+		types.MakeTableDescription([]*types.ColumnDefinition{
+			{Name: "s1", Type: strType, IsPrimaryKey: false, Comment: binaryComment},
+			{Name: "s2", Type: strType, IsPrimaryKey: false, Comment: xmlComment},
+			{Name: "s3", Type: strType, IsPrimaryKey: false, Comment: emptyComment},
+			{Name: "s4", Type: strType, IsPrimaryKey: false, Comment: emptyComment},
+			{Name: "s10", Type: strType, IsPrimaryKey: false, Comment: emptyComment},
+			{Name: "s11", Type: strType, IsPrimaryKey: false, Comment: binaryComment},
+			{Name: "s12", Type: strType, IsPrimaryKey: false, Comment: xmlComment},
+		}))
 	assert.NoError(t, err)
 	assert.Equal(t, ops, []*types.AlterTableOp{
 		{Op: types.AlterTableModify, Column: "s1", Type: &strType, Comment: &binaryComment},
@@ -154,37 +125,70 @@ func TestGetAlterTableOpsWithComments(t *testing.T) {
 	})
 }
 
-func TestGetAlterTableOpsChangePrimaryKey(t *testing.T) {
-	curCol1 := &types.ColumnDefinition{Name: "qaz", Type: "Int32", IsPrimaryKey: true}
-	curCol2 := &types.ColumnDefinition{Name: "qux", Type: "String", IsPrimaryKey: false}
-	alterCol1 := &types.ColumnDefinition{Name: "qaz", Type: "Int64", IsPrimaryKey: true}
-	alterCol2 := &types.ColumnDefinition{Name: "qux", Type: "Int64", IsPrimaryKey: false}
+func TestGetAlterTableOpsChangePrimaryKeyType(t *testing.T) {
 	ops, err := GetAlterTableOps(
-		&types.TableDescription{
-			Mapping: map[string]*types.ColumnDefinition{"qaz": curCol1, "qux": curCol2},
-			Columns: []*types.ColumnDefinition{curCol1, curCol2},
-		},
-		&types.TableDescription{
-			Mapping: map[string]*types.ColumnDefinition{"qaz": alterCol1, "qux": alterCol2},
-			Columns: []*types.ColumnDefinition{alterCol1, alterCol2},
-		})
-	assert.ErrorContains(t, err, "primary key columns cannot be changed")
+		types.MakeTableDescription([]*types.ColumnDefinition{
+			{Name: "qaz", Type: "Int32", IsPrimaryKey: true},
+			{Name: "qux", Type: "String", IsPrimaryKey: false},
+		}),
+		types.MakeTableDescription([]*types.ColumnDefinition{
+			{Name: "qaz", Type: "Int64", IsPrimaryKey: true},
+			{Name: "qux", Type: "Int64", IsPrimaryKey: false},
+		}))
+	assert.ErrorContains(t, err, "primary key columns types cannot be changed")
+	assert.Equal(t, ops, []*types.AlterTableOp(nil))
+}
+
+func TestGetAlterTableOpsChangeColumnToPrimaryKey(t *testing.T) {
+	ops, err := GetAlterTableOps(
+		types.MakeTableDescription([]*types.ColumnDefinition{
+			{Name: "qaz", Type: "Int32", IsPrimaryKey: false},
+			{Name: "qux", Type: "String", IsPrimaryKey: false},
+		}),
+		types.MakeTableDescription([]*types.ColumnDefinition{
+			{Name: "qaz", Type: "Int32", IsPrimaryKey: false},
+			{Name: "qux", Type: "String", IsPrimaryKey: true},
+		}))
+	assert.ErrorContains(t, err, "primary key columns cannot be modified")
+	assert.Equal(t, ops, []*types.AlterTableOp(nil))
+}
+
+func TestGetAlterTableOpsChangeColumnFromPrimaryKey(t *testing.T) {
+	ops, err := GetAlterTableOps(
+		types.MakeTableDescription([]*types.ColumnDefinition{
+			{Name: "qaz", Type: "Int32", IsPrimaryKey: false},
+			{Name: "qux", Type: "String", IsPrimaryKey: true},
+		}),
+		types.MakeTableDescription([]*types.ColumnDefinition{
+			{Name: "qaz", Type: "Int32", IsPrimaryKey: false},
+			{Name: "qux", Type: "Int64", IsPrimaryKey: false},
+		}))
+	assert.ErrorContains(t, err, "primary key columns cannot be modified")
 	assert.Equal(t, ops, []*types.AlterTableOp(nil))
 }
 
 func TestGetAlterTableOpsDropPrimaryKey(t *testing.T) {
-	curCol1 := &types.ColumnDefinition{Name: "qaz", Type: "Int32", IsPrimaryKey: true}
-	curCol2 := &types.ColumnDefinition{Name: "qux", Type: "String", IsPrimaryKey: false}
-	alterCol := &types.ColumnDefinition{Name: "qux", Type: "Int64", IsPrimaryKey: false}
 	ops, err := GetAlterTableOps(
-		&types.TableDescription{
-			Mapping: map[string]*types.ColumnDefinition{"qaz": curCol1, "qux": curCol2},
-			Columns: []*types.ColumnDefinition{curCol1, curCol2},
-		},
-		&types.TableDescription{
-			Mapping: map[string]*types.ColumnDefinition{"qux": alterCol},
-			Columns: []*types.ColumnDefinition{alterCol},
-		})
+		types.MakeTableDescription([]*types.ColumnDefinition{
+			{Name: "qaz", Type: "Int32", IsPrimaryKey: true},
+			{Name: "qux", Type: "String", IsPrimaryKey: false},
+		}),
+		types.MakeTableDescription([]*types.ColumnDefinition{
+			{Name: "qux", Type: "Int64", IsPrimaryKey: false},
+		}))
 	assert.ErrorContains(t, err, "primary key columns cannot be dropped")
+	assert.Equal(t, ops, []*types.AlterTableOp(nil))
+}
+
+func TestGetAlterTableOpsAddPrimaryKey(t *testing.T) {
+	ops, err := GetAlterTableOps(
+		types.MakeTableDescription([]*types.ColumnDefinition{
+			{Name: "qaz", Type: "Int32", IsPrimaryKey: true},
+		}),
+		types.MakeTableDescription([]*types.ColumnDefinition{
+			{Name: "qaz", Type: "Int32", IsPrimaryKey: true},
+			{Name: "qux", Type: "Int64", IsPrimaryKey: true},
+		}))
+	assert.ErrorContains(t, err, "primary key columns cannot be added")
 	assert.Equal(t, ops, []*types.AlterTableOp(nil))
 }

--- a/destination/db/clickhouse.go
+++ b/destination/db/clickhouse.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"sync"
+	"time"
 
 	"fivetran.com/fivetran_sdk/destination/common"
 	"fivetran.com/fivetran_sdk/destination/common/benchmark"
@@ -189,8 +190,15 @@ func (conn *ClickHouseConnection) AlterTable(
 	return conn.ExecDDL(ctx, statement, alterTable)
 }
 
-func (conn *ClickHouseConnection) TruncateTable(ctx context.Context, schemaName string, tableName string) error {
-	statement, err := sql.GetTruncateTableStatement(schemaName, tableName)
+func (conn *ClickHouseConnection) TruncateTable(
+	ctx context.Context,
+	schemaName string,
+	tableName string,
+	syncedColumn string,
+	truncateBefore time.Time,
+	softDeletedColumn *string,
+) error {
+	statement, err := sql.GetTruncateTableStatement(schemaName, tableName, syncedColumn, truncateBefore, softDeletedColumn)
 	if err != nil {
 		return err
 	}

--- a/destination/db/clickhouse.go
+++ b/destination/db/clickhouse.go
@@ -163,7 +163,7 @@ func (conn *ClickHouseConnection) CreateTable(
 	schemaName string,
 	tableName string,
 	tableDescription *types.TableDescription,
-) (err error) {
+) error {
 	statement, err := sql.GetCreateTableStatement(schemaName, tableName, tableDescription)
 	if err != nil {
 		return err
@@ -177,8 +177,11 @@ func (conn *ClickHouseConnection) AlterTable(
 	tableName string,
 	from *types.TableDescription,
 	to *types.TableDescription,
-) (err error) {
-	ops := GetAlterTableOps(from, to)
+) error {
+	ops, err := GetAlterTableOps(from, to)
+	if err != nil {
+		return err
+	}
 	statement, err := sql.GetAlterTableStatement(schemaName, tableName, ops)
 	if err != nil {
 		return err

--- a/destination/db/clickhouse.go
+++ b/destination/db/clickhouse.go
@@ -52,6 +52,7 @@ func GetClickHouseConnection(configuration map[string]string) (*ClickHouseConnec
 		Settings:     settings,
 		MaxOpenConns: int(*flags.MaxOpenConnections),
 		MaxIdleConns: int(*flags.MaxIdleConnections),
+		ReadTimeout:  *flags.RequestTimeoutDuration,
 		ClientInfo: clickhouse.ClientInfo{
 			Products: []struct {
 				Name    string

--- a/destination/db/sql/sql_test.go
+++ b/destination/db/sql/sql_test.go
@@ -2,6 +2,7 @@ package sql
 
 import (
 	"testing"
+	"time"
 
 	"fivetran.com/fivetran_sdk/destination/common/types"
 	pb "fivetran.com/fivetran_sdk/proto"
@@ -30,50 +31,50 @@ func TestGetAlterTableStatement(t *testing.T) {
 		{Op: types.AlterTableAdd, Column: "qaz", Type: &intType},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, "ALTER TABLE `foo`.`bar` ADD COLUMN qaz Int32", statement)
+	assert.Equal(t, "ALTER TABLE `foo`.`bar` ADD COLUMN `qaz` Int32", statement)
 
 	statement, err = GetAlterTableStatement("foo", "bar", []*types.AlterTableOp{
 		{Op: types.AlterTableAdd, Column: "qaz", Type: &intType, Comment: &emptyComment},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, "ALTER TABLE `foo`.`bar` ADD COLUMN qaz Int32 COMMENT ''", statement)
+	assert.Equal(t, "ALTER TABLE `foo`.`bar` ADD COLUMN `qaz` Int32 COMMENT ''", statement)
 
 	statement, err = GetAlterTableStatement("foo", "bar", []*types.AlterTableOp{
 		{Op: types.AlterTableAdd, Column: "qaz", Type: &intType, Comment: &comment},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, "ALTER TABLE `foo`.`bar` ADD COLUMN qaz Int32 COMMENT 'foobar'", statement)
+	assert.Equal(t, "ALTER TABLE `foo`.`bar` ADD COLUMN `qaz` Int32 COMMENT 'foobar'", statement)
 
 	statement, err = GetAlterTableStatement("foo", "bar", []*types.AlterTableOp{
 		{Op: types.AlterTableDrop, Column: "qaz"},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, "ALTER TABLE `foo`.`bar` DROP COLUMN qaz", statement)
+	assert.Equal(t, "ALTER TABLE `foo`.`bar` DROP COLUMN `qaz`", statement)
 
 	// Type and Comment are ignored with AlterTableDrop
 	statement, err = GetAlterTableStatement("foo", "bar", []*types.AlterTableOp{
 		{Op: types.AlterTableDrop, Column: "qaz", Type: &strType, Comment: &comment},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, "ALTER TABLE `foo`.`bar` DROP COLUMN qaz", statement)
+	assert.Equal(t, "ALTER TABLE `foo`.`bar` DROP COLUMN `qaz`", statement)
 
 	statement, err = GetAlterTableStatement("foo", "bar", []*types.AlterTableOp{
 		{Op: types.AlterTableModify, Column: "qaz", Type: &strType},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, "ALTER TABLE `foo`.`bar` MODIFY COLUMN qaz String", statement)
+	assert.Equal(t, "ALTER TABLE `foo`.`bar` MODIFY COLUMN `qaz` String", statement)
 
 	statement, err = GetAlterTableStatement("foo", "bar", []*types.AlterTableOp{
 		{Op: types.AlterTableModify, Column: "qaz", Type: &strType, Comment: &emptyComment},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, "ALTER TABLE `foo`.`bar` MODIFY COLUMN qaz String COMMENT ''", statement)
+	assert.Equal(t, "ALTER TABLE `foo`.`bar` MODIFY COLUMN `qaz` String COMMENT ''", statement)
 
 	statement, err = GetAlterTableStatement("foo", "bar", []*types.AlterTableOp{
 		{Op: types.AlterTableModify, Column: "qaz", Type: &strType, Comment: &comment},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, "ALTER TABLE `foo`.`bar` MODIFY COLUMN qaz String COMMENT 'foobar'", statement)
+	assert.Equal(t, "ALTER TABLE `foo`.`bar` MODIFY COLUMN `qaz` String COMMENT 'foobar'", statement)
 
 	statement, err = GetAlterTableStatement("", "bar", []*types.AlterTableOp{
 		{Op: types.AlterTableAdd, Column: "qaz", Type: &strType, Comment: &comment},
@@ -83,7 +84,7 @@ func TestGetAlterTableStatement(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Equal(t,
-		"ALTER TABLE `bar` ADD COLUMN qaz String COMMENT 'foobar', DROP COLUMN qux, MODIFY COLUMN zaq Int32 COMMENT '', MODIFY COLUMN qwe String",
+		"ALTER TABLE `bar` ADD COLUMN `qaz` String COMMENT 'foobar', DROP COLUMN `qux`, MODIFY COLUMN `zaq` Int32 COMMENT '', MODIFY COLUMN `qwe` String",
 		statement)
 
 	_, err = GetAlterTableStatement("foo", "bar", []*types.AlterTableOp{})
@@ -100,33 +101,36 @@ func TestGetAlterTableStatement(t *testing.T) {
 }
 
 func TestGetCreateTableStatement(t *testing.T) {
-	statement, err := GetCreateTableStatement("foo", "bar", &types.TableDescription{
-		Columns: []*types.ColumnDefinition{
+	statement, err := GetCreateTableStatement("foo", "bar",
+		types.MakeTableDescription([]*types.ColumnDefinition{
 			{Name: "qaz", Type: "Int32"},
 			{Name: "qux", Type: "String", IsPrimaryKey: true},
-		},
-	})
+			{Name: "_fivetran_synced", Type: "DateTime64(9, 'UTC')"},
+			{Name: "_fivetran_deleted", Type: "Boolean"},
+		}))
 	assert.NoError(t, err)
-	assert.Equal(t, "CREATE TABLE `foo`.`bar` (qaz Int32, qux String) ENGINE = ReplacingMergeTree(_fivetran_synced) ORDER BY (qux)", statement)
+	assert.Equal(t, "CREATE TABLE `foo`.`bar` (`qaz` Int32, `qux` String, `_fivetran_synced` DateTime64(9, 'UTC'), `_fivetran_deleted` Boolean) ENGINE = ReplacingMergeTree(`_fivetran_synced`) ORDER BY (`qux`)", statement)
 
-	statement, err = GetCreateTableStatement("", "bar", &types.TableDescription{
-		Columns: []*types.ColumnDefinition{
+	statement, err = GetCreateTableStatement("", "bar",
+		types.MakeTableDescription([]*types.ColumnDefinition{
 			{Name: "qaz", Type: "Int32", IsPrimaryKey: true},
 			{Name: "qux", Type: "String", IsPrimaryKey: true},
-		},
-	})
+			{Name: "_fivetran_synced", Type: "DateTime64(9, 'UTC')"},
+			{Name: "_fivetran_deleted", Type: "Boolean"},
+		}))
 	assert.NoError(t, err)
-	assert.Equal(t, "CREATE TABLE `bar` (qaz Int32, qux String) ENGINE = ReplacingMergeTree(_fivetran_synced) ORDER BY (qaz, qux)", statement)
+	assert.Equal(t, "CREATE TABLE `bar` (`qaz` Int32, `qux` String, `_fivetran_synced` DateTime64(9, 'UTC'), `_fivetran_deleted` Boolean) ENGINE = ReplacingMergeTree(`_fivetran_synced`) ORDER BY (`qaz`, `qux`)", statement)
 
-	statement, err = GetCreateTableStatement("", "bar", &types.TableDescription{
-		Columns: []*types.ColumnDefinition{
+	statement, err = GetCreateTableStatement("", "bar",
+		types.MakeTableDescription([]*types.ColumnDefinition{
 			{Name: "i", Type: "Int32", IsPrimaryKey: true},
 			{Name: "x", Type: "String", IsPrimaryKey: false, Comment: "XML"},
 			{Name: "bin", Type: "String", IsPrimaryKey: false, Comment: "BINARY"},
-		},
-	})
+			{Name: "_fivetran_synced", Type: "DateTime64(9, 'UTC')"},
+			{Name: "_fivetran_deleted", Type: "Boolean"},
+		}))
 	assert.NoError(t, err)
-	assert.Equal(t, "CREATE TABLE `bar` (i Int32, x String COMMENT 'XML', bin String COMMENT 'BINARY') ENGINE = ReplacingMergeTree(_fivetran_synced) ORDER BY (i)", statement)
+	assert.Equal(t, "CREATE TABLE `bar` (`i` Int32, `x` String COMMENT 'XML', `bin` String COMMENT 'BINARY', `_fivetran_synced` DateTime64(9, 'UTC'), `_fivetran_deleted` Boolean) ENGINE = ReplacingMergeTree(`_fivetran_synced`) ORDER BY (`i`)", statement)
 
 	_, err = GetCreateTableStatement("foo", "", nil)
 	assert.ErrorContains(t, err, "table name is empty")
@@ -136,19 +140,51 @@ func TestGetCreateTableStatement(t *testing.T) {
 
 	_, err = GetCreateTableStatement("foo", "bar", &types.TableDescription{})
 	assert.ErrorContains(t, err, "no columns to create table `foo`.`bar`")
+
+	_, err = GetCreateTableStatement("foo", "bar",
+		types.MakeTableDescription([]*types.ColumnDefinition{{Name: "qaz", Type: "Int32"}}))
+	assert.ErrorContains(t, err, "no primary keys for table `foo`.`bar`")
+
+	_, err = GetCreateTableStatement("foo", "bar",
+		types.MakeTableDescription([]*types.ColumnDefinition{{Name: "qaz", Type: "Int32", IsPrimaryKey: true}}))
+	assert.ErrorContains(t, err, "no _fivetran_synced column")
+
+	_, err = GetCreateTableStatement("foo", "bar",
+		types.MakeTableDescription([]*types.ColumnDefinition{
+			{Name: "qaz", Type: "Int32", IsPrimaryKey: true},
+			{Name: "_fivetran_synced", Type: "DateTime64(9, 'UTC')"}}))
+	assert.ErrorContains(t, err, "no _fivetran_deleted column")
 }
 
 func TestGetTruncateTableStatement(t *testing.T) {
-	statement, err := GetTruncateTableStatement("foo", "bar")
-	assert.NoError(t, err)
-	assert.Equal(t, "TRUNCATE TABLE `foo`.`bar`", statement)
+	emptyStr := ""
+	syncedColumn := "_fivetran_synced"
+	softDeletedColumn := "_fivetran_deleted"
+	truncateBefore := time.Unix(1646455512, 123456789)
 
-	statement, err = GetTruncateTableStatement("", "bar")
-	assert.NoError(t, err)
-	assert.Equal(t, "TRUNCATE TABLE `bar`", statement)
+	expectedHard := "ALTER TABLE `foo`.`bar` DELETE WHERE `_fivetran_synced` < '1646455512123456789'"
+	expectedSoft := "ALTER TABLE `foo`.`bar` UPDATE `_fivetran_deleted` = 1 WHERE `_fivetran_synced` < '1646455512123456789'"
 
-	_, err = GetTruncateTableStatement("foo", "")
+	statement, err := GetTruncateTableStatement("foo", "bar", syncedColumn, truncateBefore, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedHard, statement)
+
+	statement, err = GetTruncateTableStatement("foo", "bar", syncedColumn, truncateBefore, &emptyStr)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedHard, statement)
+
+	statement, err = GetTruncateTableStatement("foo", "bar", syncedColumn, truncateBefore, &softDeletedColumn)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedSoft, statement)
+
+	_, err = GetTruncateTableStatement("foo", "", syncedColumn, truncateBefore, nil)
 	assert.ErrorContains(t, err, "table name is empty")
+
+	_, err = GetTruncateTableStatement("foo", "bar", "", truncateBefore, nil)
+	assert.ErrorContains(t, err, "synced column name is empty")
+
+	_, err = GetTruncateTableStatement("foo", "bar", syncedColumn, time.Unix(0, 0), nil)
+	assert.ErrorContains(t, err, "truncate before time is zero")
 }
 
 func TestGetColumnTypesQuery(t *testing.T) {
@@ -196,7 +232,7 @@ func TestGetSelectByPrimaryKeysQuery(t *testing.T) {
 	}
 	query, err := GetSelectByPrimaryKeysQuery(batch, fullTableName, pkCols)
 	assert.NoError(t, err)
-	assert.Equal(t, "SELECT * FROM `foo`.`bar` FINAL WHERE (id) IN ((42), (43)) ORDER BY (id) LIMIT 2", query)
+	assert.Equal(t, "SELECT * FROM `foo`.`bar` FINAL WHERE (`id`) IN ((42), (43)) ORDER BY (`id`) LIMIT 2", query)
 
 	batch = [][]string{
 		{"42", "foo", "2022-03-05T04:45:12.123456789Z", "false"},
@@ -210,5 +246,5 @@ func TestGetSelectByPrimaryKeysQuery(t *testing.T) {
 	}
 	query, err = GetSelectByPrimaryKeysQuery(batch, fullTableName, pkCols)
 	assert.NoError(t, err)
-	assert.Equal(t, "SELECT * FROM `foo`.`bar` FINAL WHERE (id, name) IN ((42, 'foo'), (43, 'bar'), (44, 'qaz'), (45, 'qux')) ORDER BY (id, name) LIMIT 4", query)
+	assert.Equal(t, "SELECT * FROM `foo`.`bar` FINAL WHERE (`id`, `name`) IN ((42, 'foo'), (43, 'bar'), (44, 'qaz'), (45, 'qux')) ORDER BY (`id`, `name`) LIMIT 4", query)
 }

--- a/destination/main_e2e_test.go
+++ b/destination/main_e2e_test.go
@@ -138,8 +138,8 @@ func TestTruncateBefore(t *testing.T) {
 	//  should be possible to test it "properly" with future SDK releases, currently it's a workaround,
 	//  as truncate operation is always last and all the input.json rows are merged into one "replace" CSV file.
 	//  With a fixed version, direct conn calls should be replaced with SDK tester calls instead.
-	fileName := "input_truncate_create_table.json"
-	tableName := "table_to_truncate"
+	fileName := "input_truncate_before.json"
+	tableName := "truncate_before"
 
 	startServer(t)
 	conf := readConfigMap(t)

--- a/destination/main_e2e_test.go
+++ b/destination/main_e2e_test.go
@@ -240,9 +240,7 @@ func TestTruncateExistingRecordsThenSync(t *testing.T) {
 	err = conn.SoftDeleteBatch(ctx, schemaName, table, metadata.PrimaryKeys, colTypes, deleteCSV, metadata.FivetranSyncedIdx, metadata.FivetranDeletedIdx, 100, 100, 5)
 	require.NoError(t, err)
 
-	// FIXME: this is actually wrong.
-	//  While the final values are correct, we are missing previous "soft truncated" records.
-	//  Those were replaced with their newer versions via ReplacingMergeTree.
+	// Soft truncated rows are merged out, we have only the newest versions via ReplacingMergeTree.
 	assertTableRowsWithPK(t, tableName, [][]string{
 		{"1", "name-replaced-1", "desc-updated-1", "false"},
 		{"2", "name-replaced-2", "desc-replaced-2", "true"}})

--- a/destination/main_e2e_test.go
+++ b/destination/main_e2e_test.go
@@ -233,11 +233,11 @@ func TestTruncateExistingRecordsThenSync(t *testing.T) {
 		{"2", nullStr, nullStr, syncTime, "true"},
 	}
 
-	err = conn.ReplaceBatch(ctx, schemaName, table, replaceCSV, nullStr, 100)
+	err = conn.ReplaceBatch(ctx, schemaName, table, replaceCSV, nullStr)
 	require.NoError(t, err)
-	err = conn.UpdateBatch(ctx, schemaName, table, metadata.PrimaryKeys, colTypes, updateCSV, nullStr, unmodifiedStr, 100, 100, 5)
+	err = conn.UpdateBatch(ctx, schemaName, table, metadata.PrimaryKeys, colTypes, updateCSV, nullStr, unmodifiedStr)
 	require.NoError(t, err)
-	err = conn.SoftDeleteBatch(ctx, schemaName, table, metadata.PrimaryKeys, colTypes, deleteCSV, metadata.FivetranSyncedIdx, metadata.FivetranDeletedIdx, 100, 100, 5)
+	err = conn.SoftDeleteBatch(ctx, schemaName, table, metadata.PrimaryKeys, colTypes, deleteCSV, metadata.FivetranSyncedIdx, metadata.FivetranDeletedIdx)
 	require.NoError(t, err)
 
 	// Soft truncated rows are merged out, we have only the newest versions via ReplacingMergeTree.

--- a/destination/service/columns_test.go
+++ b/destination/service/columns_test.go
@@ -130,3 +130,47 @@ func TestToClickHouseColumns(t *testing.T) {
 	_, err = ToClickHouse(&pb.Table{Columns: []*pb.Column{{Name: "a", Type: pb.DataType_UNSPECIFIED}}})
 	assert.ErrorContains(t, err, "unknown datatype UNSPECIFIED")
 }
+
+func TestGetPrimaryKeysAndMetadataColumns(t *testing.T) {
+	pkCols, err := GetPrimaryKeysAndMetadataColumns(&pb.Table{Columns: []*pb.Column{
+		{Name: "i16", Type: pb.DataType_SHORT, PrimaryKey: false},
+		{Name: "i32", Type: pb.DataType_INT, PrimaryKey: false},
+		{Name: "str", Type: pb.DataType_STRING, PrimaryKey: true},
+		{Name: "_fivetran_synced", Type: pb.DataType_UTC_DATETIME, PrimaryKey: false},
+		{Name: "_fivetran_deleted", Type: pb.DataType_BOOLEAN, PrimaryKey: false},
+	}})
+	assert.NoError(t, err)
+	assert.Equal(t, pkCols, &types.PrimaryKeysAndMetadataColumns{
+		PrimaryKeys: []*types.PrimaryKeyColumn{
+			{Index: 2, Name: "str", Type: pb.DataType_STRING},
+		},
+		FivetranSyncedIdx:  3,
+		FivetranDeletedIdx: 4,
+	})
+
+	pkCols, err = GetPrimaryKeysAndMetadataColumns(nil)
+	assert.ErrorContains(t, err, "no columns in Fivetran table definition")
+
+	pkCols, err = GetPrimaryKeysAndMetadataColumns(&pb.Table{})
+	assert.ErrorContains(t, err, "no columns in Fivetran table definition")
+
+	pkCols, err = GetPrimaryKeysAndMetadataColumns(&pb.Table{Columns: []*pb.Column{}})
+	assert.ErrorContains(t, err, "no columns in Fivetran table definition")
+
+	pkCols, err = GetPrimaryKeysAndMetadataColumns(&pb.Table{Columns: []*pb.Column{
+		{Name: "a", Type: pb.DataType_STRING},
+	}})
+	assert.ErrorContains(t, err, "no primary keys found")
+
+	pkCols, err = GetPrimaryKeysAndMetadataColumns(&pb.Table{Columns: []*pb.Column{
+		{Name: "a", Type: pb.DataType_STRING, PrimaryKey: true},
+		{Name: "_fivetran_synced", Type: pb.DataType_UTC_DATETIME, PrimaryKey: false},
+	}})
+	assert.ErrorContains(t, err, "no _fivetran_deleted column found")
+
+	pkCols, err = GetPrimaryKeysAndMetadataColumns(&pb.Table{Columns: []*pb.Column{
+		{Name: "a", Type: pb.DataType_STRING, PrimaryKey: true},
+		{Name: "_fivetran_deleted", Type: pb.DataType_BOOLEAN, PrimaryKey: false},
+	}})
+	assert.ErrorContains(t, err, "no _fivetran_synced column found")
+}

--- a/destination/service/responses.go
+++ b/destination/service/responses.go
@@ -109,6 +109,14 @@ func FailedAlterTableResponse(schemaName string, tableName string, err error) *p
 	}
 }
 
+func SuccessfulTruncateTableResponse() *pb.TruncateResponse {
+	return &pb.TruncateResponse{
+		Response: &pb.TruncateResponse_Success{
+			Success: true,
+		},
+	}
+}
+
 func FailedTruncateTableResponse(schemaName string, tableName string, err error) *pb.TruncateResponse {
 	logError("TruncateTable", err)
 	return &pb.TruncateResponse{

--- a/destination/service/server.go
+++ b/destination/service/server.go
@@ -3,11 +3,10 @@ package service
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"fivetran.com/fivetran_sdk/destination/common/benchmark"
-	"fivetran.com/fivetran_sdk/destination/common/constants"
 	"fivetran.com/fivetran_sdk/destination/common/flags"
-	"fivetran.com/fivetran_sdk/destination/common/types"
 	"fivetran.com/fivetran_sdk/destination/db"
 	pb "fivetran.com/fivetran_sdk/proto"
 )
@@ -132,16 +131,27 @@ func (s *Server) Truncate(ctx context.Context, in *pb.TruncateRequest) (*pb.Trun
 	}
 	defer conn.Close()
 
-	err = conn.TruncateTable(ctx, in.SchemaName, in.TableName)
+	// should not be failed if the table does not exist, as per SDK documentation
+	tableDescription, err := conn.DescribeTable(ctx, in.SchemaName, in.TableName)
+	if err != nil {
+		return FailedTruncateTableResponse(in.SchemaName, in.TableName, err), nil
+	}
+	if tableDescription == nil || len(tableDescription.Columns) == 0 {
+		return SuccessfulTruncateTableResponse(), nil
+	}
+
+	var softDeleteColumn *string = nil
+	if in.Soft != nil && in.Soft.DeletedColumn != "" {
+		softDeleteColumn = &in.Soft.DeletedColumn
+	}
+
+	truncateBefore := time.Unix(in.UtcDeleteBefore.Seconds, int64(in.UtcDeleteBefore.Nanos)).UTC()
+	err = conn.TruncateTable(ctx, in.SchemaName, in.TableName, in.SyncedColumn, truncateBefore, softDeleteColumn)
 	if err != nil {
 		return FailedTruncateTableResponse(in.SchemaName, in.TableName, err), nil
 	}
 
-	return &pb.TruncateResponse{
-		Response: &pb.TruncateResponse_Success{
-			Success: true,
-		},
-	}, nil
+	return SuccessfulTruncateTableResponse(), nil
 }
 
 func (s *Server) WriteBatch(ctx context.Context, in *pb.WriteBatchRequest) (*pb.WriteBatchResponse, error) {
@@ -159,32 +169,9 @@ func (s *Server) WriteBatch(ctx context.Context, in *pb.WriteBatchRequest) (*pb.
 		return FailedWriteBatchResponse(in.SchemaName, in.Table.Name, fmt.Errorf("write batch request without CSV params")), nil
 	}
 
-	var pkCols []*types.PrimaryKeyColumn
-	fivetranSyncedIdx := -1
-	fivetranDeletedIdx := -1
-	for i, col := range in.Table.Columns {
-		if col.PrimaryKey {
-			pkCols = append(pkCols, &types.PrimaryKeyColumn{
-				Name:  col.Name,
-				Type:  col.Type,
-				Index: uint(i),
-			})
-		}
-		if col.Name == constants.FivetranSynced {
-			fivetranSyncedIdx = i
-		}
-		if col.Name == constants.FivetranDeleted {
-			fivetranDeletedIdx = i
-		}
-	}
-	if len(pkCols) == 0 {
-		return FailedWriteBatchResponse(in.SchemaName, in.Table.Name, fmt.Errorf("no primary keys found")), nil
-	}
-	if fivetranSyncedIdx < 0 {
-		return FailedWriteBatchResponse(in.SchemaName, in.Table.Name, fmt.Errorf("no %s column found", constants.FivetranSynced)), nil
-	}
-	if fivetranDeletedIdx < 0 {
-		return FailedWriteBatchResponse(in.SchemaName, in.Table.Name, fmt.Errorf("no %s column found", constants.FivetranDeleted)), nil
+	metadata, err := GetPrimaryKeysAndMetadataColumns(in.Table)
+	if err != nil {
+		return FailedWriteBatchResponse(in.SchemaName, in.Table.Name, err), nil
 	}
 
 	conn, err := db.GetClickHouseConnection(in.GetConfiguration())
@@ -226,7 +213,7 @@ func (s *Server) WriteBatch(ctx context.Context, in *pb.WriteBatchRequest) (*pb.
 					if err != nil {
 						return err
 					}
-					err = conn.UpdateBatch(ctx, in.SchemaName, in.Table, pkCols, columnTypes, csvData,
+					err = conn.UpdateBatch(ctx, in.SchemaName, in.Table, metadata.PrimaryKeys, columnTypes, csvData,
 						nullStr, unmodifiedStr,
 						*flags.WriteBatchSize, *flags.SelectBatchSize, *flags.MaxParallelSelects)
 					if err != nil {
@@ -247,8 +234,8 @@ func (s *Server) WriteBatch(ctx context.Context, in *pb.WriteBatchRequest) (*pb.
 					if err != nil {
 						return err
 					}
-					err = conn.SoftDeleteBatch(ctx, in.SchemaName, in.Table, pkCols, columnTypes, csvData,
-						uint(fivetranSyncedIdx), uint(fivetranDeletedIdx),
+					err = conn.SoftDeleteBatch(ctx, in.SchemaName, in.Table, metadata.PrimaryKeys, columnTypes, csvData,
+						metadata.FivetranSyncedIdx, metadata.FivetranDeletedIdx,
 						*flags.WriteBatchSize, *flags.SelectBatchSize, *flags.MaxParallelSelects)
 					if err != nil {
 						return err

--- a/destination/service/server.go
+++ b/destination/service/server.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"fivetran.com/fivetran_sdk/destination/common/benchmark"
-	"fivetran.com/fivetran_sdk/destination/common/flags"
 	"fivetran.com/fivetran_sdk/destination/db"
 	pb "fivetran.com/fivetran_sdk/proto"
 )
@@ -194,7 +193,7 @@ func (s *Server) WriteBatch(ctx context.Context, in *pb.WriteBatchRequest) (*pb.
 					if err != nil {
 						return err
 					}
-					err = conn.ReplaceBatch(ctx, in.SchemaName, in.Table, csvData, nullStr, *flags.WriteBatchSize)
+					err = conn.ReplaceBatch(ctx, in.SchemaName, in.Table, csvData, nullStr)
 					if err != nil {
 						return err
 					}
@@ -214,8 +213,7 @@ func (s *Server) WriteBatch(ctx context.Context, in *pb.WriteBatchRequest) (*pb.
 						return err
 					}
 					err = conn.UpdateBatch(ctx, in.SchemaName, in.Table, metadata.PrimaryKeys, columnTypes, csvData,
-						nullStr, unmodifiedStr,
-						*flags.WriteBatchSize, *flags.SelectBatchSize, *flags.MaxParallelSelects)
+						nullStr, unmodifiedStr)
 					if err != nil {
 						return err
 					}
@@ -235,8 +233,7 @@ func (s *Server) WriteBatch(ctx context.Context, in *pb.WriteBatchRequest) (*pb.
 						return err
 					}
 					err = conn.SoftDeleteBatch(ctx, in.SchemaName, in.Table, metadata.PrimaryKeys, columnTypes, csvData,
-						metadata.FivetranSyncedIdx, metadata.FivetranDeletedIdx,
-						*flags.WriteBatchSize, *flags.SelectBatchSize, *flags.MaxParallelSelects)
+						metadata.FivetranSyncedIdx, metadata.FivetranDeletedIdx)
 					if err != nil {
 						return err
 					}

--- a/sdk_tests/input_truncate_before.json
+++ b/sdk_tests/input_truncate_before.json
@@ -1,6 +1,6 @@
 {
   "create_table": {
-    "table_to_truncate": {
+    "truncate_before": {
       "columns": {
         "id": "INT",
         "name": "STRING"
@@ -11,12 +11,12 @@
     }
   },
   "describe_table": [
-    "table_to_truncate"
+    "truncate_before"
   ],
   "ops": [
     {
       "upsert": {
-        "table_to_truncate": [
+        "truncate_before": [
           {
             "id": 2,
             "name": "bar"

--- a/sdk_tests/input_truncate_create_table.json
+++ b/sdk_tests/input_truncate_create_table.json
@@ -18,21 +18,6 @@
       "upsert": {
         "table_to_truncate": [
           {
-            "id": 1,
-            "name": "foo"
-          }
-        ]
-      }
-    },
-    {
-      "truncate": [
-        "table_to_truncate"
-      ]
-    },
-    {
-      "upsert": {
-        "table_to_truncate": [
-          {
             "id": 2,
             "name": "bar"
           },

--- a/sdk_tests/input_truncate_then_sync.json
+++ b/sdk_tests/input_truncate_then_sync.json
@@ -1,0 +1,40 @@
+{
+  "create_table": {
+    "truncate_then_sync": {
+      "columns": {
+        "id": "INT",
+        "name": "STRING",
+        "desc": "STRING"
+      },
+      "primary_key": [
+        "id"
+      ]
+    }
+  },
+  "describe_table": [
+    "truncate_then_sync"
+  ],
+  "ops": [
+    {
+      "truncate": [
+        "truncate_then_sync"
+      ]
+    },
+    {
+      "upsert": {
+        "truncate_then_sync": [
+          {
+            "id": 1,
+            "name": "name-truncated-1",
+            "desc": "desc-truncated-1"
+          },
+          {
+            "id": 2,
+            "name": "name-truncated-2",
+            "desc": "desc-truncated-2"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
* Allow AlterTable requests to be executed only for non-PK columns. Altering PKs should be properly implemented after #4.
* Fully implement TruncateTable logic (truncate before a certain time, soft delete all records, hard delete all records).
* Proper SQL identifiers in all statements.
* Moved out the logic about metadata and primary key column index calculation out of the `server.go` file (was useful for tests separately).
* Added a request timeout flag.

## Checklist
- [x] Unit and integration tests covering the common scenarios were added

