### PR TITLE
Add grants test, create databases if necessary, handle sync column with millis precision

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ sdk-test:
 		-e WORKING_DIR=$$PWD/sdk_tests \
 		-e GRPC_HOSTNAME=172.17.0.1 \
 		--network=host \
-		fivetrandocker/sdk-destination-tester:024.0222.002 $$TEST_ARGS
+		fivetrandocker/sdk-destination-tester:024.0306.001 $$TEST_ARGS
 
 recreate-test-db:
 	curl --data-binary "DROP DATABASE IF EXISTS tester" http://localhost:8123

--- a/destination/common/retry/retry.go
+++ b/destination/common/retry/retry.go
@@ -50,7 +50,7 @@ func OnNetError(
 		}
 	}
 	if err != nil {
-		return fmt.Errorf("failed to execute %s after %d attempts: %w", opName, *flags.MaxRetries, err)
+		return fmt.Errorf("%s failed after %d attempts: %w", opName, *flags.MaxRetries, err)
 	}
 	return nil
 }
@@ -96,7 +96,7 @@ func OnNetErrorWithData[T any](
 	}
 	if err != nil {
 		var empty T
-		return empty, fmt.Errorf("failed to execute %s after %d attempts: %w", opName, *flags.MaxRetries, err)
+		return empty, fmt.Errorf("%s failed after %d attempts: %w", opName, *flags.MaxRetries, err)
 	}
 	return data, nil
 }

--- a/destination/common/retry/retry_test.go
+++ b/destination/common/retry/retry_test.go
@@ -82,7 +82,7 @@ func TestRetryNetError(t *testing.T) {
 		}
 		return makeNetError()
 	}, context.Background(), "TestRetryNetError", false)
-	assert.ErrorContains(t, err, "failed to execute TestRetryNetError after 2 attempts")
+	assert.ErrorContains(t, err, "TestRetryNetError failed after 2 attempts")
 }
 
 func TestRetryNetErrorWithData(t *testing.T) {
@@ -117,7 +117,7 @@ func TestRetryNetErrorWithData(t *testing.T) {
 		}
 		return 0, makeNetError()
 	}, context.Background(), "TestRetryNetErrorWithData", false)
-	assert.ErrorContains(t, err, "failed to execute TestRetryNetErrorWithData after 2 attempts")
+	assert.ErrorContains(t, err, "TestRetryNetErrorWithData failed after 2 attempts")
 
 	// also works with an arbitrary type
 	dataT, err := OnNetErrorWithData(func() (myType, error) {
@@ -145,7 +145,7 @@ func TestRetryNetErrorWithData(t *testing.T) {
 		}
 		return myType{}, makeNetError()
 	}, context.Background(), "TestRetryNetErrorWithData(T)", false)
-	assert.ErrorContains(t, err, "failed to execute TestRetryNetErrorWithData(T) after 2 attempts")
+	assert.ErrorContains(t, err, "TestRetryNetErrorWithData(T) failed after 2 attempts")
 }
 
 func TestRetryNetErrorDelayConfiguration(t *testing.T) {

--- a/destination/common/types/types.go
+++ b/destination/common/types/types.go
@@ -55,3 +55,11 @@ type AlterTableOp struct {
 	Type    *string // nil for AlterTableDrop
 	Comment *string // nil for AlterTableDrop
 }
+
+// UserGrant represents a row from system.grants table.
+type UserGrant struct {
+	AccessType string
+	Database   *string
+	Table      *string
+	Column     *string
+}

--- a/destination/db/clickhouse.go
+++ b/destination/db/clickhouse.go
@@ -79,13 +79,13 @@ func GetClickHouseConnection(ctx context.Context, configuration map[string]strin
 	}
 	err = retry.OnNetError(func() error {
 		return conn.Ping(ctx)
-	}, ctx, "Ping", false)
+	}, ctx, "ping", false)
 	if err != nil {
 		if err.Error() == "EOF" {
-			err = fmt.Errorf("ping ClickHouse service error: unexpected EOF; " +
+			err = fmt.Errorf("ClickHouse connection error: unexpected EOF; " +
 				"this may indicate that incoming traffic is not allowed in the service networking settings")
 		} else {
-			err = fmt.Errorf("ping ClickHouse service error: %w", err)
+			err = fmt.Errorf("ClickHouse connection error: %w", err)
 		}
 		log.Error(err)
 		return nil, err

--- a/destination/db/clickhouse_integration_test.go
+++ b/destination/db/clickhouse_integration_test.go
@@ -1,0 +1,135 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnection(t *testing.T) {
+	ctx := context.Background()
+	conn, err := GetClickHouseConnection(ctx, map[string]string{
+		"host":     "localhost",
+		"port":     "9000",
+		"username": "default",
+		"local":    "true",
+	})
+	require.NoError(t, err)
+	defer conn.Close()
+
+	err = conn.ConnectionTest(ctx)
+	require.NoError(t, err)
+}
+
+func TestGrants(t *testing.T) {
+	guid := func() string {
+		return strings.ReplaceAll(uuid.New().String(), "-", "")
+	}
+
+	ctx := context.Background()
+	defaultConn, err := GetClickHouseConnection(ctx, map[string]string{
+		"host":     "localhost",
+		"port":     "9000",
+		"username": "default",
+		"local":    "true",
+	})
+	require.NoError(t, err)
+
+	username := fmt.Sprintf("test_grants_user_%s", guid())
+	password := fmt.Sprintf("secret_%s", guid())
+	defer func() {
+		dropUserStatement := fmt.Sprintf("DROP USER IF EXISTS %s", username)
+		err = defaultConn.ExecDDL(ctx, dropUserStatement, "[TestGrants] DropUser")
+		assert.NoError(t, err)
+		err = defaultConn.Close()
+		require.NoError(t, err)
+	}()
+
+	createUserStatement := fmt.Sprintf("CREATE USER %s IDENTIFIED BY '%s'", username, password)
+	err = defaultConn.ExecDDL(ctx, createUserStatement, "[TestGrants] CreateUser")
+	require.NoError(t, err)
+
+	conn, err := GetClickHouseConnection(ctx, map[string]string{
+		"host":     "localhost",
+		"port":     "9000",
+		"username": username,
+		"password": password,
+		"local":    "true",
+	})
+	require.NoError(t, err)
+	defer conn.Close()
+
+	addGrant := func(grant string) {
+		grantCreateDatabaseStatement := fmt.Sprintf("GRANT %s ON *.* TO %s", grant, username)
+		err = defaultConn.ExecDDL(ctx, grantCreateDatabaseStatement, "")
+		require.NoError(t, err)
+	}
+
+	// users start with zero privileges and the first check immediately fails
+	err = conn.GrantsTest(ctx)
+	assert.ErrorContains(t, err, "it's necessary to have the grant SHOW USERS, SHOW ROLES ON *.*")
+
+	// gradually add more privileges
+	addGrant("SHOW USERS, SHOW ROLES")
+	err = conn.GrantsTest(ctx)
+	assert.ErrorContains(t, err, "user is missing the required grants: "+
+		"ALTER ADD COLUMN, ALTER DELETE, ALTER DROP COLUMN, ALTER MODIFY COLUMN, ALTER UPDATE, "+
+		"CREATE DATABASE, CREATE TABLE, INSERT, SELECT, SHOW COLUMNS, SHOW TABLES")
+
+	addGrant("ALTER ADD COLUMN")
+	err = conn.GrantsTest(ctx)
+	assert.ErrorContains(t, err, "user is missing the required grants: "+
+		"ALTER DELETE, ALTER DROP COLUMN, ALTER MODIFY COLUMN, ALTER UPDATE, "+
+		"CREATE DATABASE, CREATE TABLE, INSERT, SELECT, SHOW COLUMNS, SHOW TABLES")
+
+	addGrant("ALTER DELETE")
+	err = conn.GrantsTest(ctx)
+	assert.ErrorContains(t, err, "user is missing the required grants: "+
+		"ALTER DROP COLUMN, ALTER MODIFY COLUMN, ALTER UPDATE, "+
+		"CREATE DATABASE, CREATE TABLE, INSERT, SELECT, SHOW COLUMNS, SHOW TABLES")
+
+	addGrant("ALTER DROP COLUMN")
+	err = conn.GrantsTest(ctx)
+	assert.ErrorContains(t, err, "user is missing the required grants: "+
+		"ALTER MODIFY COLUMN, ALTER UPDATE, CREATE DATABASE, CREATE TABLE, INSERT, SELECT, SHOW COLUMNS, SHOW TABLES")
+
+	addGrant("ALTER MODIFY COLUMN")
+	err = conn.GrantsTest(ctx)
+	assert.ErrorContains(t, err, "user is missing the required grants: "+
+		"ALTER UPDATE, CREATE DATABASE, CREATE TABLE, INSERT, SELECT, SHOW COLUMNS, SHOW TABLES")
+
+	addGrant("ALTER UPDATE")
+	err = conn.GrantsTest(ctx)
+	assert.ErrorContains(t, err, "user is missing the required grants: "+
+		"CREATE DATABASE, CREATE TABLE, INSERT, SELECT, SHOW COLUMNS, SHOW TABLES")
+
+	addGrant("CREATE DATABASE")
+	err = conn.GrantsTest(ctx)
+	assert.ErrorContains(t, err, "user is missing the required grants: "+
+		"CREATE TABLE, INSERT, SELECT, SHOW COLUMNS, SHOW TABLES")
+
+	addGrant("CREATE TABLE")
+	err = conn.GrantsTest(ctx)
+	assert.ErrorContains(t, err, "user is missing the required grants: INSERT, SELECT, SHOW COLUMNS, SHOW TABLES")
+
+	addGrant("INSERT")
+	err = conn.GrantsTest(ctx)
+	assert.ErrorContains(t, err, "user is missing the required grants: SELECT, SHOW COLUMNS, SHOW TABLES")
+
+	addGrant("SELECT")
+	err = conn.GrantsTest(ctx)
+	assert.ErrorContains(t, err, "user is missing the required grants: SHOW COLUMNS, SHOW TABLES")
+
+	addGrant("SHOW COLUMNS")
+	err = conn.GrantsTest(ctx)
+	assert.ErrorContains(t, err, "user is missing the required grants: SHOW TABLES")
+
+	addGrant("SHOW TABLES")
+	err = conn.GrantsTest(ctx)
+	require.NoError(t, err)
+}

--- a/destination/db/config/config.go
+++ b/destination/db/config/config.go
@@ -8,36 +8,35 @@ import (
 
 const (
 	HostKey     = "host"
-	DatabaseKey = "database"
+	PortKey     = "port"
 	UsernameKey = "username"
 	PasswordKey = "password"
 )
 
 type Config struct {
 	Host     string
-	Database string
+	Port     uint
 	Username string
 	Password string
 	Local    bool
 }
 
+// TODO: validate host
+
 // Parse ClickHouse connection config from a Fivetran config map that we receive on every GRPC call.
 func Parse(configuration map[string]string) (*Config, error) {
-	host := GetWithDefault(configuration, HostKey, "localhost:9000", true)
-	hostSplit := strings.Split(host, ":")
-	if len(hostSplit) != 2 {
-		return nil, fmt.Errorf("%s must be in the format address:port", host)
-	}
-	port, err := strconv.Atoi(hostSplit[1])
+	host := GetWithDefault(configuration, HostKey, "localhost", true)
+	portStr := GetWithDefault(configuration, PortKey, "9000", true)
+	port, err := strconv.Atoi(portStr)
 	if err != nil {
-		return nil, fmt.Errorf("%s port %s must be a number in range [1, 65535]", host, hostSplit[1])
+		return nil, fmt.Errorf("port %s must be a number in range [1, 65535]", portStr)
 	}
 	if port < 1 || port > 65535 {
-		return nil, fmt.Errorf("%s port %s must be in range [1, 65535]", host, hostSplit[1])
+		return nil, fmt.Errorf("port %s must be in range [1, 65535]", portStr)
 	}
 	return &Config{
-		Host:     GetWithDefault(configuration, HostKey, "localhost:9000", true),
-		Database: GetWithDefault(configuration, DatabaseKey, "default", true),
+		Host:     host,
+		Port:     uint(port),
 		Username: GetWithDefault(configuration, UsernameKey, "default", true),
 		Password: GetWithDefault(configuration, PasswordKey, "", false),
 		Local:    GetWithDefault(configuration, "local", "false", true) == "true",

--- a/destination/db/config/config_test.go
+++ b/destination/db/config/config_test.go
@@ -22,16 +22,16 @@ func TestGetWithDefaultTrim(t *testing.T) {
 
 func TestParseConfig(t *testing.T) {
 	defaultConfig := Config{
-		Host:     "localhost:9000",
-		Database: "default",
+		Host:     "localhost",
+		Port:     9000,
 		Username: "default",
 		Password: "",
 		Local:    false,
 	}
 	withHostOnly := defaultConfig
-	withHostOnly.Host = "my.host:9440"
-	withDatabaseOnly := defaultConfig
-	withDatabaseOnly.Database = "my_db"
+	withHostOnly.Host = "my.host"
+	withPortOnly := defaultConfig
+	withPortOnly.Port = 9440
 	withUsernameOnly := defaultConfig
 	withUsernameOnly.Username = "5t"
 	withPasswordOnly := defaultConfig
@@ -44,14 +44,15 @@ func TestParseConfig(t *testing.T) {
 		{
 			name: "valid config (all set)",
 			configuration: map[string]string{
-				"host":     "my.host:9440",
+				"host":     "my.host",
+				"port":     "9440",
 				"database": "my_db",
 				"username": "5t",
 				"password": "foo_bar",
 			},
 			expected: &Config{
-				Host:     "my.host:9440",
-				Database: "my_db",
+				Host:     "my.host",
+				Port:     9440,
 				Username: "5t",
 				Password: "foo_bar",
 				Local:    false,
@@ -61,8 +62,8 @@ func TestParseConfig(t *testing.T) {
 			name:          "valid config (all defaults)",
 			configuration: map[string]string{},
 			expected: &Config{
-				Host:     "localhost:9000",
-				Database: "default",
+				Host:     "localhost",
+				Port:     9000,
 				Username: "default",
 				Password: "",
 				Local:    false,
@@ -70,13 +71,13 @@ func TestParseConfig(t *testing.T) {
 		},
 		{
 			name:          "valid config (host only)",
-			configuration: map[string]string{"host": "my.host:9440"},
+			configuration: map[string]string{"host": "my.host"},
 			expected:      &withHostOnly,
 		},
 		{
-			name:          "valid config (database only)",
-			configuration: map[string]string{"database": "my_db"},
-			expected:      &withDatabaseOnly,
+			name:          "valid config (port only)",
+			configuration: map[string]string{"port": "9440"},
+			expected:      &withPortOnly,
 		},
 		{
 			name:          "valid config (username only)",
@@ -104,23 +105,23 @@ func TestParseConfigErrors(t *testing.T) {
 	}{
 		{
 			name:          "invalid port",
-			configuration: map[string]string{"host": "ch:foo"},
-			expectedError: "ch:foo port foo must be a number in range [1, 65535]",
+			configuration: map[string]string{"port": "foo"},
+			expectedError: "port foo must be a number in range [1, 65535]",
 		},
 		{
 			name:          "invalid port > 65535",
-			configuration: map[string]string{"host": "ch:65536"},
-			expectedError: "ch:65536 port 65536 must be in range [1, 65535]",
+			configuration: map[string]string{"port": "65536"},
+			expectedError: "port 65536 must be in range [1, 65535]",
 		},
 		{
 			name:          "invalid port 0",
-			configuration: map[string]string{"host": "ch:0"},
-			expectedError: "ch:0 port 0 must be in range [1, 65535]",
+			configuration: map[string]string{"port": "0"},
+			expectedError: "port 0 must be in range [1, 65535]",
 		},
 		{
 			name:          "invalid port < 0",
-			configuration: map[string]string{"host": "ch:-1"},
-			expectedError: "ch:-1 port -1 must be in range [1, 65535]",
+			configuration: map[string]string{"port": "-1"},
+			expectedError: "port -1 must be in range [1, 65535]",
 		},
 	}
 	for _, test := range tests {

--- a/destination/db/config/config_test.go
+++ b/destination/db/config/config_test.go
@@ -8,16 +8,16 @@ import (
 
 func TestGetWithDefault(t *testing.T) {
 	configuration := map[string]string{"key": "value"}
-	assert.Equal(t, "value", GetWithDefault(configuration, "key", "default", false))
-	assert.Equal(t, "default", GetWithDefault(configuration, "missing", "default", false))
-	assert.Equal(t, "", GetWithDefault(configuration, "missing", "", false))
+	assert.Equal(t, "value", getWithDefault(configuration, "key", "default", false))
+	assert.Equal(t, "default", getWithDefault(configuration, "missing", "default", false))
+	assert.Equal(t, "", getWithDefault(configuration, "missing", "", false))
 }
 
 func TestGetWithDefaultTrim(t *testing.T) {
 	configuration := map[string]string{"key": " value "}
-	assert.Equal(t, "value", GetWithDefault(configuration, "key", "default", true))
-	assert.Equal(t, " value ", GetWithDefault(configuration, "key", "default", false))
-	assert.Equal(t, "default", GetWithDefault(configuration, "missing", "default", true))
+	assert.Equal(t, "value", getWithDefault(configuration, "key", "default", true))
+	assert.Equal(t, " value ", getWithDefault(configuration, "key", "default", false))
+	assert.Equal(t, "default", getWithDefault(configuration, "missing", "default", true))
 }
 
 func TestParseConfig(t *testing.T) {
@@ -129,4 +129,19 @@ func TestParseConfigErrors(t *testing.T) {
 		assert.ErrorContains(t, err, test.expectedError, "Test %s", test.name)
 		assert.Equal(t, (*Config)(nil), actual, "Test %s", test.name)
 	}
+}
+
+func TestConfigHostValidation(t *testing.T) {
+	parsed, err := Parse(map[string]string{"host": "my.host"})
+	assert.NoError(t, err)
+	assert.Equal(t, "my.host", parsed.Host)
+
+	_, err = Parse(map[string]string{"host": "my.host:9000"})
+	assert.ErrorContains(t, err, "host my.host:9000 should not contain protocol or port")
+
+	_, err = Parse(map[string]string{"host": "my.host/path"})
+	assert.ErrorContains(t, err, "host my.host/path should not contain path")
+
+	_, err = Parse(map[string]string{"host": "tcp://my.host"})
+	assert.ErrorContains(t, err, "host tcp://my.host should not contain protocol or port")
 }

--- a/destination/db/rows_integration_test.go
+++ b/destination/db/rows_integration_test.go
@@ -16,11 +16,13 @@ import (
 )
 
 func TestColumnTypesToEmptyRows(t *testing.T) {
-	conn, err := GetClickHouseConnection(map[string]string{
-		"host":     "localhost:9000",
-		"username": "default",
-		"local":    "true",
-	})
+	conn, err := GetClickHouseConnection(
+		context.Background(),
+		map[string]string{
+			"host":     "localhost:9000",
+			"username": "default",
+			"local":    "true",
+		})
 	require.NoError(t, err)
 	defer conn.Close()
 
@@ -122,11 +124,13 @@ func TestColumnTypesToEmptyRows(t *testing.T) {
 }
 
 func TestGetDatabaseRowMappingKey(t *testing.T) {
-	conn, err := GetClickHouseConnection(map[string]string{
-		"host":     "localhost:9000",
-		"username": "default",
-		"local":    "true",
-	})
+	conn, err := GetClickHouseConnection(
+		context.Background(),
+		map[string]string{
+			"host":     "localhost:9000",
+			"username": "default",
+			"local":    "true",
+		})
 	require.NoError(t, err)
 	defer conn.Close()
 

--- a/destination/db/rows_integration_test.go
+++ b/destination/db/rows_integration_test.go
@@ -19,7 +19,8 @@ func TestColumnTypesToEmptyRows(t *testing.T) {
 	conn, err := GetClickHouseConnection(
 		context.Background(),
 		map[string]string{
-			"host":     "localhost:9000",
+			"host":     "localhost",
+			"port":     "9000",
 			"username": "default",
 			"local":    "true",
 		})
@@ -127,7 +128,8 @@ func TestGetDatabaseRowMappingKey(t *testing.T) {
 	conn, err := GetClickHouseConnection(
 		context.Background(),
 		map[string]string{
-			"host":     "localhost:9000",
+			"host":     "localhost",
+			"port":     "9000",
 			"username": "default",
 			"local":    "true",
 		})

--- a/destination/db/sql/sql_test.go
+++ b/destination/db/sql/sql_test.go
@@ -271,7 +271,7 @@ func TestGetSelectByPrimaryKeysQuery(t *testing.T) {
 func TestGetCheckDatabaseExistsStatement(t *testing.T) {
 	statement, err := GetCheckDatabaseExistsStatement("foo")
 	assert.NoError(t, err)
-	assert.Equal(t, "SELECT COUNT(*) FROM system.databases WHERE name = 'foo'", statement)
+	assert.Equal(t, "SELECT COUNT(*) FROM system.databases WHERE `name` = 'foo'", statement)
 
 	_, err = GetCheckDatabaseExistsStatement("")
 	assert.ErrorContains(t, err, "schema name is empty")
@@ -284,4 +284,13 @@ func TestGetCreateDatabaseStatement(t *testing.T) {
 
 	_, err = GetCreateDatabaseStatement("")
 	assert.ErrorContains(t, err, "schema name is empty")
+}
+
+func TestGetSelectFromSystemGrantsQuery(t *testing.T) {
+	query, err := GetSelectFromSystemGrantsQuery("foo")
+	assert.NoError(t, err)
+	assert.Equal(t, "SELECT `access_type`, `database`, `table`, `column` FROM system.grants WHERE `user_name` = 'foo'", query)
+
+	_, err = GetSelectFromSystemGrantsQuery("")
+	assert.ErrorContains(t, err, "username is empty")
 }

--- a/destination/main_e2e_test.go
+++ b/destination/main_e2e_test.go
@@ -243,7 +243,7 @@ func TestTruncateBefore(t *testing.T) {
 
 	startServer(t)
 	conf := readConfigMap(t)
-	conn, err := db.GetClickHouseConnection(conf)
+	conn, err := db.GetClickHouseConnection(context.Background(), conf)
 	require.NoError(t, err)
 	defer conn.Close()
 
@@ -287,7 +287,7 @@ func TestTruncateExistingRecordsThenSync(t *testing.T) {
 
 	startServer(t)
 	conf := readConfigMap(t)
-	conn, err := db.GetClickHouseConnection(conf)
+	conn, err := db.GetClickHouseConnection(context.Background(), conf)
 	require.NoError(t, err)
 	defer conn.Close()
 
@@ -543,14 +543,11 @@ func readConfig(t *testing.T) *config.Config {
 
 func runQuery(t *testing.T, query string) string {
 	conf := readConfig(t)
-	split := strings.Split(conf.Host, ":")
-	require.Len(t, split, 2)
 	cmdArgs := []string{
 		"exec", "fivetran-destination-clickhouse-server",
 		"clickhouse-client", "--query", query,
-		"--host", split[0],
-		"--port", split[1],
-		"--database", conf.Database,
+		"--host", conf.Host,
+		"--port", fmt.Sprint(conf.Port),
 		"--user", conf.Username,
 		"--password", conf.Password,
 	}
@@ -606,7 +603,7 @@ func runSDKTestCommand(t *testing.T, inputFileName string, recreateDatabase bool
 	}
 	require.NoError(t, err)
 	out := string(byteOut)
-	require.Contains(t, out, "[Test connection and basic operations]: PASSED")
+	require.Contains(t, out, "[Connection test]: PASSED")
 }
 
 var schemaName = "tester"

--- a/destination/service/responses.go
+++ b/destination/service/responses.go
@@ -25,8 +25,8 @@ func GetConfigurationFormResponse() *pb.ConfigurationFormResponse {
 				},
 			},
 			{
-				Name:     config.DatabaseKey,
-				Label:    "Database",
+				Name:     config.PortKey,
+				Label:    "Port",
 				Required: true,
 				Type: &pb.FormField_TextField{
 					TextField: pb.TextField_PlainText,
@@ -37,7 +37,7 @@ func GetConfigurationFormResponse() *pb.ConfigurationFormResponse {
 				Label:    "Username",
 				Required: true,
 				Type: &pb.FormField_TextField{
-					TextField: pb.TextField_Password,
+					TextField: pb.TextField_PlainText,
 				},
 			},
 			{
@@ -52,7 +52,11 @@ func GetConfigurationFormResponse() *pb.ConfigurationFormResponse {
 		Tests: []*pb.ConfigurationTest{
 			{
 				Name:  ConnectionTest,
-				Label: "Test connection and basic operations",
+				Label: "Connection test",
+			},
+			{
+				Name:  GrantsTest,
+				Label: "User grants test",
 			},
 		},
 	}

--- a/destination/service/responses.go
+++ b/destination/service/responses.go
@@ -8,7 +8,8 @@ import (
 	pb "fivetran.com/fivetran_sdk/proto"
 )
 
-var hostDescription = "ClickHouse Cloud service host. Format: address:port"
+var hostDescription = "ClickHouse Cloud service host without protocol or port. For example, my.service.clickhouse.cloud"
+var portDescription = "ClickHouse Cloud service native protocol SSL/TLS port. Usually, it is 9440"
 
 func GetConfigurationFormResponse() *pb.ConfigurationFormResponse {
 	return &pb.ConfigurationFormResponse{
@@ -25,9 +26,10 @@ func GetConfigurationFormResponse() *pb.ConfigurationFormResponse {
 				},
 			},
 			{
-				Name:     config.PortKey,
-				Label:    "Port",
-				Required: true,
+				Name:        config.PortKey,
+				Label:       "Port",
+				Description: &portDescription,
+				Required:    true,
 				Type: &pb.FormField_TextField{
 					TextField: pb.TextField_PlainText,
 				},

--- a/sdk_tests/default_configuration.json
+++ b/sdk_tests/default_configuration.json
@@ -1,6 +1,6 @@
 {
-  "host": "clickhouse:9000",
-  "database": "default",
+  "host": "clickhouse",
+  "port": "9000",
   "password": "",
   "username": "default",
   "local": "true"


### PR DESCRIPTION
## Summary
* The destination will now test the required grants as a part of connection tests.
* Added a ping call (with retries) after opening the connection.
* Handle sync column with millis precision instead of nanos.
* Split the host and port in the configuration form and add some host configuration validation.
* Better error messages (networking settings hints, grants etc).
* Alter table requests will not fail if there are no changes to be applied.
* Fixed username field type in the configuration form.

NB: there is a drop table method in the connection now that I initially wanted to use for the "mutations" test, which later was replaced with just grants check; so it is currently unused but might be useful for #4, so I decided to keep it. 

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
