### PR TITLE
Handle "Database ... is currently dropped or renamed" error

### DIFF
--- a/destination/common/flags/flags.go
+++ b/destination/common/flags/flags.go
@@ -45,3 +45,8 @@ var MaxAsyncMutationsCheckRetries = flag.Uint("max-async-mutations-check-retries
 	"Max number of retries when checking async mutations status before failing")
 var AsyncMutationsCheckInterval = flag.Duration("async-mutations-check-interval", 1*time.Second,
 	"Interval between async mutations status check retries")
+
+var MaxDatabaseCreatedCheckRetries = flag.Uint("max-database-created-check-retries", 30,
+	"Max number of retries when checking database creation status before failing")
+var DatabaseCreatedCheckInterval = flag.Duration("database-created-check-interval", 1*time.Second,
+	"Interval between database creation status check retries")

--- a/destination/db/values/values.go
+++ b/destination/db/values/values.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"fivetran.com/fivetran_sdk/destination/common/constants"
-	"fivetran.com/fivetran_sdk/destination/common/log"
 	pb "fivetran.com/fivetran_sdk/proto"
 	"github.com/shopspring/decimal"
 )
@@ -90,11 +89,9 @@ func Parse(colName string, colType pb.DataType, val string) (any, error) {
 		// See https://clickhouse.com/docs/en/sql-reference/data-types/datetime64
 		year := result.Year()
 		if year < 1900 {
-			log.Warn(fmt.Sprintf("Date value %s is before 1900, truncating to 1900-01-01", val))
 			return time.Date(1900, time.January, 1, 0, 0, 0, 0, time.UTC), nil
 		}
 		if year > 2299 {
-			log.Warn(fmt.Sprintf("Date value %s is after 2299, truncating to 2299-12-31", val))
 			return time.Date(2299, time.December, 31, 0, 0, 0, 0, time.UTC), nil
 		}
 		return result, nil
@@ -107,11 +104,9 @@ func Parse(colName string, colType pb.DataType, val string) (any, error) {
 		// See https://clickhouse.com/docs/en/sql-reference/data-types/datetime64
 		year := result.Year()
 		if year < 1900 {
-			log.Warn(fmt.Sprintf("DateTime value %s is before 1900, truncating to 1900-01-01 00:00:00", val))
 			return time.Date(1900, time.January, 1, 0, 0, 0, 0, time.UTC), nil
 		}
 		if year > 2299 {
-			log.Warn(fmt.Sprintf("DateTime value %s is after 2299, truncating to 2299-12-31 23:59:59", val))
 			return time.Date(2299, time.December, 31, 23, 59, 59, 0, time.UTC), nil
 		}
 		return result, nil
@@ -124,17 +119,14 @@ func Parse(colName string, colType pb.DataType, val string) (any, error) {
 		// See https://clickhouse.com/docs/en/sql-reference/data-types/datetime64
 		year, month, day := result.Date()
 		if year > 2262 || (year == 2262 && month > 4) || (year == 2262 && month == 4 && day > 11) {
-			log.Warn(fmt.Sprintf("UTC DateTime value %s is after 2262-04-11 23:47:16, truncating to that value", val))
 			return time.Date(2262, time.April, 11, 23, 47, 16, 0, time.UTC), nil
 		}
 		if year < 1900 {
-			log.Warn(fmt.Sprintf("UTC DateTime value %s is before 1900, truncating to 1900-01-01 00:00:00", val))
 			return time.Date(1900, time.January, 1, 0, 0, 0, 0, time.UTC), nil
 		}
 		hours, minutes, seconds := result.Clock()
 		if year == 2262 && month == 4 && day == 11 && hours == 23 {
 			if minutes > 47 || minutes == 47 && seconds > 16 || minutes == 47 && seconds == 16 && result.Nanosecond() > 0 {
-				log.Warn(fmt.Sprintf("UTC DateTime value %s is after 2262-04-11 23:47:16, truncating to that value", val))
 				return time.Date(2262, time.April, 11, 23, 47, 16, 0, time.UTC), nil
 			}
 		}


### PR DESCRIPTION
## Summary

* Handle "Database ... is currently dropped or renamed" error (a rare one)
* Remove unnecessary warnings when a DateTime value is truncated

