### PR TITLE
Fixes check for zero  time argument to accept values with zero seconds and nanos like date only

### DIFF
--- a/destination/db/sql/sql.go
+++ b/destination/db/sql/sql.go
@@ -182,17 +182,20 @@ func GetTruncateTableStatement(
 	if err != nil {
 		return "", err
 	}
+
 	if syncedColumn == "" {
 		return "", fmt.Errorf("synced column name is empty")
 	}
 
-	truncateBeforeMilli := truncateBefore.UnixMilli()
-	if truncateBeforeMilli == 0 {
-		return "", fmt.Errorf("truncate before time is 0")
+	if truncateBefore.IsZero() {
+		return "", fmt.Errorf("truncate before time is zero")
 	}
 
 	var query string
+
 	syncedColumnMilli := toUnixTimestamp64Milli(identifier(syncedColumn))
+	truncateBeforeMilli := truncateBefore.UnixMilli()
+
 	if softDeletedColumn != nil && *softDeletedColumn != "" {
 		query = fmt.Sprintf("ALTER TABLE %s UPDATE %s = 1 WHERE %s <= '%d'",
 			fullName, identifier(*softDeletedColumn), syncedColumnMilli, truncateBeforeMilli)
@@ -200,6 +203,7 @@ func GetTruncateTableStatement(
 		query = fmt.Sprintf("ALTER TABLE %s DELETE WHERE %s <= '%d'",
 			fullName, syncedColumnMilli, truncateBeforeMilli)
 	}
+
 	return query, nil
 }
 

--- a/destination/db/sql/sql_test.go
+++ b/destination/db/sql/sql_test.go
@@ -195,7 +195,7 @@ func TestGetTruncateTableStatement(t *testing.T) {
 	_, err = GetTruncateTableStatement("foo", "bar", "", truncateBefore, nil)
 	assert.ErrorContains(t, err, "synced column name is empty")
 
-	_, err = GetTruncateTableStatement("foo", "bar", syncedColumn, time.Unix(0, 0), nil)
+	_, err = GetTruncateTableStatement("foo", "bar", syncedColumn, time.Time{}, nil)
 	assert.ErrorContains(t, err, "truncate before time is zero")
 
 	truncateBeforeDate := time.Date(2000, 1, 15, 14, 35, 0, 0, time.UTC)


### PR DESCRIPTION
## Summary
- Fixes check for zero  time argument to accept values with zero seconds and nanos like date only

Check in the function was: 

```go
if truncateBefore.Second() == 0 && truncateBefore.Nanosecond() == 0 {
	return "", fmt.Errorf("truncate before time is zero")
}
``` 
It checks only if second and nanoseconds are `0` and will fail for when date is used and whole time part is zero. 
Current PR fixes it by checking `truncateBefore.UnixMilli()` that will return milliseconds value (that is further used to construct statement) that represent whole `truncateBefore`.  


Closes: https://github.com/ClickHouse/clickhouse-fivetran-destination/issues/48

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
