### PR TITLE
POC settings override

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,7 @@ make recreate-test-db && make sdk-test
 ```
 
 See also: Fivetran SDK
-tester [documentation](https://github.com/fivetran/fivetran_sdk/tree/main/tools/destination-tester).
+tester [documentation](https://github.com/fivetran/fivetran_partner_sdk/blob/main/tools/destination-connector-tester).
 
 ## Lint
 

--- a/destination/db/clickhouse.go
+++ b/destination/db/clickhouse.go
@@ -378,6 +378,7 @@ func (conn *ClickHouseConnection) CreateTable(
 	schemaName string,
 	tableName string,
 	tableDescription *types.TableDescription,
+	tableSettings *config.TableSettings,
 ) error {
 	databaseExists, err := conn.CheckDatabaseExists(ctx, schemaName)
 	if err != nil {
@@ -389,7 +390,7 @@ func (conn *ClickHouseConnection) CreateTable(
 			return err
 		}
 	}
-	statement, err := sql.GetCreateTableStatement(schemaName, tableName, tableDescription)
+	statement, err := sql.GetCreateTableStatement(schemaName, tableName, tableDescription, tableSettings)
 	if err != nil {
 		return err
 	}
@@ -403,6 +404,7 @@ func (conn *ClickHouseConnection) AlterTable(
 	tableName string,
 	from *types.TableDescription,
 	to *types.TableDescription,
+	tableSettings *config.TableSettings,
 ) (wasExecuted bool, err error) {
 	ops, hasChangedPK, unchangedColNames, err := GetAlterTableOps(from, to)
 	if err != nil {
@@ -419,7 +421,7 @@ func (conn *ClickHouseConnection) AlterTable(
 		backupTableName := fmt.Sprintf("%s_backup_%d", tableName, unixMilli)
 		log.Info(fmt.Sprintf("AlterTable with PK change detected; backup table name: %s, new table name: %s",
 			backupTableName, newTableName))
-		createTableStmt, err := sql.GetCreateTableStatement(schemaName, newTableName, to)
+		createTableStmt, err := sql.GetCreateTableStatement(schemaName, newTableName, to, tableSettings)
 		if err != nil {
 			return false, err
 		}

--- a/destination/db/config/config.go
+++ b/destination/db/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -11,6 +13,8 @@ const (
 	PortKey     = "port"
 	UsernameKey = "username"
 	PasswordKey = "password"
+
+	AdvancedConfigKey = "advanced_config"
 )
 
 type Config struct {
@@ -19,6 +23,50 @@ type Config struct {
 	Username string
 	Password string
 	Local    bool
+}
+
+// AdvancedConfig is the top-level structure of the optional JSON configuration file
+// uploaded via the Fivetran setup form.
+type AdvancedConfig struct {
+	DestinationSettings     *DestinationSettings     `json:"destination_settings,omitempty"`
+	ClickHouseQuerySettings map[string]any            `json:"clickhouse_query_settings,omitempty"`
+	Tables                  map[string]*TableSettings `json:"tables,omitempty"`
+}
+
+// DestinationSettings controls the internal behavior of the destination connector.
+type DestinationSettings struct {
+	WriteBatchSize      *uint `json:"write_batch_size,omitempty"`
+	SelectBatchSize     *uint `json:"select_batch_size,omitempty"`
+	HardDeleteBatchSize *uint `json:"hard_delete_batch_size,omitempty"`
+	MaxParallelSelects  *uint `json:"max_parallel_selects,omitempty"`
+	MaxIdleConnections  *uint `json:"max_idle_connections,omitempty"`
+	MaxOpenConnections  *uint `json:"max_open_connections,omitempty"`
+	RequestTimeoutSecs  *uint `json:"request_timeout_seconds,omitempty"`
+}
+
+// TableSettings holds per-table CREATE TABLE configuration.
+type TableSettings struct {
+	OrderBy  []string       `json:"order_by,omitempty"`
+	Settings map[string]any `json:"settings,omitempty"`
+}
+
+// SettingsClause serializes the Settings map into a SQL-compatible SETTINGS clause value.
+// e.g. {"index_granularity": 2048, "storage_policy": "hot_cold"} becomes
+// "index_granularity=2048, storage_policy='hot_cold'"
+func (ts *TableSettings) SettingsClause() string {
+	if ts == nil || len(ts.Settings) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(ts.Settings))
+	for k, v := range ts.Settings {
+		switch val := v.(type) {
+		case string:
+			parts = append(parts, fmt.Sprintf("%s='%s'", k, val))
+		default:
+			parts = append(parts, fmt.Sprintf("%s=%v", k, val))
+		}
+	}
+	return strings.Join(parts, ", ")
 }
 
 // Parse ClickHouse connection config from a Fivetran config map that we receive on every GRPC call.
@@ -38,6 +86,40 @@ func Parse(configuration map[string]string) (*Config, error) {
 		Password: getWithDefault(configuration, PasswordKey, "", false),
 		Local:    getWithDefault(configuration, "local", "false", true) == "true",
 	}, nil
+}
+
+// ParseAdvancedConfig decodes and parses the optional JSON configuration file
+// from the Fivetran config map. The file is base64-encoded by Fivetran's UploadField.
+// Returns a zero-value AdvancedConfig if the key is absent or empty.
+func ParseAdvancedConfig(configuration map[string]string) (*AdvancedConfig, error) {
+	raw := getWithDefault(configuration, AdvancedConfigKey, "", false)
+	if raw == "" {
+		return &AdvancedConfig{}, nil
+	}
+
+	jsonBytes, err := base64.StdEncoding.DecodeString(raw)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode advanced config (expected base64): %w", err)
+	}
+
+	var cfg AdvancedConfig
+	if err := json.Unmarshal(jsonBytes, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse advanced config JSON: %w", err)
+	}
+
+	return &cfg, nil
+}
+
+// ResolveTableSettings returns the TableSettings for a specific table,
+// falling back to defaults if no per-table configuration exists.
+func (c *AdvancedConfig) ResolveTableSettings(schemaName, tableName string) *TableSettings {
+	if c != nil && c.Tables != nil {
+		key := schemaName + "." + tableName
+		if ts, ok := c.Tables[key]; ok {
+			return ts
+		}
+	}
+	return &TableSettings{}
 }
 
 func getWithDefault(configuration map[string]string, key string, defaultValue string, trim bool) string {

--- a/destination/service/responses.go
+++ b/destination/service/responses.go
@@ -10,12 +10,14 @@ import (
 
 var hostDescription = "ClickHouse Cloud service host without protocol or port. For example, my.service.clickhouse.cloud"
 var portDescription = "ClickHouse Cloud service native protocol SSL/TLS port. Default is 9440"
+var advancedConfigDescription = "Optional JSON configuration file for fine-tuning destination behavior, ClickHouse query settings, and per-table options such as ORDER BY columns, and table-level SETTINGS. See the documentation for the file schema"
 
 func GetConfigurationFormResponse() *pb.ConfigurationFormResponse {
 	isHostRequired := true
 	isPortRequired := false
 	isUserNameRequired := true
 	isPasswordRequired := true
+	isNotRequired := false
 	return &pb.ConfigurationFormResponse{
 		SchemaSelectionSupported: true,
 		TableSelectionSupported:  true,
@@ -52,6 +54,18 @@ func GetConfigurationFormResponse() *pb.ConfigurationFormResponse {
 				Required: &isPasswordRequired,
 				Type: &pb.FormField_TextField{
 					TextField: pb.TextField_Password,
+				},
+			},
+			{
+				Name:        config.AdvancedConfigKey,
+				Label:       "Advanced Configuration",
+				Description: &advancedConfigDescription,
+				Required:    &isNotRequired,
+				Type: &pb.FormField_UploadField{
+					UploadField: &pb.UploadField{
+						AllowedFileType:  []string{".json"},
+						MaxFileSizeBytes: 5_242_880, // 5 MiB
+					},
 				},
 			},
 		},


### PR DESCRIPTION
## Summary
Closes https://github.com/ClickHouse/clickhouse-fivetran-destination/issues/59

- Implements the new JSON file. We decided to follow the JSON path as we may need in the future more advanced configurations. Check the [setup.md in this PR](https://github.com/ClickHouse/clickhouse-fivetran-destination/pull/63/changes#diff-4fc7e78a455625ec3780f4d7a9d807b461b71cd4ee0c73cf9be551bfa397ec29) to see how it would look like
- Only allows overriding 3 specific settings. I have decided to go this way to simplify the configuration to users, but it's easy to add more if needed.
- I have also updated the documentation file to explain how this works

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
