### PR TITLE
Update sdk tester version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 FIVETRAN_TAG     = "8b30d60b8eb2040f858c3f3c1ab819daed9fd84d"
 FIVETRAN_SDK_URL = "https://raw.githubusercontent.com/fivetran/fivetran_partner_sdk/$(FIVETRAN_TAG)"
 
-SDK_TESTER_VERSION = "2.25.1118.001"
+SDK_TESTER_VERSION = "2.26.0408.001"
 SDK_TESTER_IMAGE   = "us-docker.pkg.dev/build-286712/public-docker-us/sdktesters-v2/sdk-tester:$(SDK_TESTER_VERSION)"
 
 PROTOC_GEN_GO_VERSION = "v1.36.10"

--- a/destination/db/values/values.go
+++ b/destination/db/values/values.go
@@ -10,6 +10,15 @@ import (
 	"github.com/shopspring/decimal"
 )
 
+// MaxDateTime64 is the maximum DateTime64(9, 'UTC') value supported by ClickHouse.
+// DateTime64(9) stores nanoseconds since epoch as int64; this is the upper-bound date
+// that fits within int64 range. All incoming dates beyond this are clamped to this value.
+// Used as the sentinel _fivetran_end value for active history mode rows.
+var MaxDateTime64 = time.Date(2262, time.April, 11, 23, 47, 16, 0, time.UTC)
+
+// MaxDateTime64Nanos is MaxDateTime64 as a nanosecond-since-epoch string, ready for SQL interpolation.
+var MaxDateTime64Nanos = strconv.FormatInt(MaxDateTime64.UnixNano(), 10)
+
 func Value(colType pb.DataType, value string) (string, error) {
 	switch colType {
 	case // quote types that we can pass as a string
@@ -105,7 +114,7 @@ func Parse(colName string, colType pb.DataType, val string) (any, error) {
 		// However, due to the way the driver works, the actual upper bound is 2262-04-11 23:47:16.
 		year, month, day := result.Date()
 		if year > 2262 || (year == 2262 && month > 4) || (year == 2262 && month == 4 && day > 11) {
-			return time.Date(2262, time.April, 11, 23, 47, 16, 0, time.UTC), nil
+			return MaxDateTime64, nil
 		}
 		if year < 1900 {
 			return time.Date(1900, time.January, 1, 0, 0, 0, 0, time.UTC), nil
@@ -113,7 +122,7 @@ func Parse(colName string, colType pb.DataType, val string) (any, error) {
 		hours, minutes, seconds := result.Clock()
 		if year == 2262 && month == 4 && day == 11 && hours == 23 {
 			if minutes > 47 || minutes == 47 && seconds > 16 || minutes == 47 && seconds == 16 {
-				return time.Date(2262, time.April, 11, 23, 47, 16, 0, time.UTC), nil
+				return MaxDateTime64, nil
 			}
 		}
 		return result, nil
@@ -126,7 +135,7 @@ func Parse(colName string, colType pb.DataType, val string) (any, error) {
 		// See https://clickhouse.com/docs/en/sql-reference/data-types/datetime64
 		year, month, day := result.Date()
 		if year > 2262 || (year == 2262 && month > 4) || (year == 2262 && month == 4 && day > 11) {
-			return time.Date(2262, time.April, 11, 23, 47, 16, 0, time.UTC), nil
+			return MaxDateTime64, nil
 		}
 		if year < 1900 {
 			return time.Date(1900, time.January, 1, 0, 0, 0, 0, time.UTC), nil
@@ -134,7 +143,7 @@ func Parse(colName string, colType pb.DataType, val string) (any, error) {
 		hours, minutes, seconds := result.Clock()
 		if year == 2262 && month == 4 && day == 11 && hours == 23 {
 			if minutes > 47 || minutes == 47 && seconds > 16 || minutes == 47 && seconds == 16 && result.Nanosecond() > 0 {
-				return time.Date(2262, time.April, 11, 23, 47, 16, 0, time.UTC), nil
+				return MaxDateTime64, nil
 			}
 		}
 		return result, nil

--- a/destination/main_e2e_test.go
+++ b/destination/main_e2e_test.go
@@ -33,10 +33,10 @@ func TestAllDataTypes(t *testing.T) {
 	assertTableRowsWithFivetranID(t, tableName, [][]string{
 		{"true", "42", "144", "100500", "100.5", "200.5", "42.42",
 			"2024-05-07", "2024-04-05 15:33:14", "2024-02-03 12:44:22.123456789",
-			"foo", "{\"a\": 1,\"b\": 2}", "<a>1</a>", "FFFA", "15:00", "abc-123-xyz"},
+			"foo", "{\"a\": 1,\"b\": 2}", "<a>1</a>", "FFFA", "15:00", "abc-123-xyz", "false"},
 		{"false", "-42", "-144", "-100500", "-100.5", "-200.5", "-42.42",
 			"2021-02-03", "2021-06-15 04:15:16", "2021-02-03 14:47:45.234567890",
-			"bar", "{\"c\": 3,\"d\": 4}", "<b>42</b>", "FFFE", "12:42", "vbn-543-hjk"}})
+			"bar", "{\"c\": 3,\"d\": 4}", "<b>42</b>", "FFFE", "12:42", "vbn-543-hjk", "false"}})
 	assertTableColumns(t, tableName, [][]string{
 		{"b", "Nullable(Bool)", ""},
 		{"i16", "Nullable(Int16)", ""},
@@ -54,7 +54,8 @@ func TestAllDataTypes(t *testing.T) {
 		{"bin", "Nullable(String)", "BINARY"},
 		{"nt", "Nullable(String)", "NAIVE_TIME"},
 		{"_fivetran_synced", "DateTime64(9, 'UTC')", ""},
-		{"_fivetran_id", "String", ""}})
+		{"_fivetran_id", "String", ""},
+		{"_fivetran_deleted", "Bool", ""}})
 }
 
 func TestMutateAfterAlter(t *testing.T) {
@@ -63,9 +64,9 @@ func TestMutateAfterAlter(t *testing.T) {
 	startServer(t)
 	runSDKTestCommand(t, fileName, true)
 	assertTableRowsWithPK(t, tableName, [][]string{
-		{"1", "200", "asd", "zxc", "\\N", "\\N"},
-		{"2", "50", "\\N", "\\N", "<c>99</c>", "DD"},
-		{"4", "20.5", "x", "\\N", "<d>77</d>", "\\N"}})
+		{"1", "200", "asd", "zxc", "\\N", "\\N", "false"},
+		{"2", "50", "\\N", "\\N", "<c>99</c>", "DD", "false"},
+		{"4", "20.5", "x", "\\N", "<d>77</d>", "\\N", "false"}})
 	assertTableColumns(t, tableName, [][]string{
 		{"id", "Int32", ""},
 		{"amount", "Nullable(Float32)", ""},
@@ -73,7 +74,8 @@ func TestMutateAfterAlter(t *testing.T) {
 		{"s2", "Nullable(String)", ""},
 		{"s3", "Nullable(String)", "XML"},
 		{"s4", "Nullable(String)", "BINARY"},
-		{"_fivetran_synced", "DateTime64(9, 'UTC')", ""}})
+		{"_fivetran_synced", "DateTime64(9, 'UTC')", ""},
+		{"_fivetran_deleted", "Bool", ""}})
 }
 
 func TestUpdateAndHardDelete(t *testing.T) {
@@ -82,12 +84,13 @@ func TestUpdateAndHardDelete(t *testing.T) {
 	startServer(t)
 	runSDKTestCommand(t, fileName, true)
 	assertTableRowsWithPK(t, tableName, [][]string{
-		{"1", "1111"},
-		{"2", "two"}})
+		{"1", "1111", "false"},
+		{"2", "two", "false"}})
 	assertTableColumns(t, tableName, [][]string{
 		{"id", "Int32", ""},
 		{"name", "Nullable(String)", ""},
-		{"_fivetran_synced", "DateTime64(9, 'UTC')", ""}})
+		{"_fivetran_synced", "DateTime64(9, 'UTC')", ""},
+		{"_fivetran_deleted", "Bool", ""}})
 }
 
 func TestSoftDelete(t *testing.T) {
@@ -114,13 +117,14 @@ func TestUTCDateTimePrimaryKey(t *testing.T) {
 	startServer(t)
 	runSDKTestCommand(t, fileName, true)
 	assertTableRowsWithPKColumns(t, tableName, [][]string{
-		{"144", "2024-01-14 15:13:12.000000000"},
-		{"2", "2024-01-14 15:13:12.123000000"}},
+		{"144", "2024-01-14 15:13:12.000000000", "false"},
+		{"2", "2024-01-14 15:13:12.123000000", "false"}},
 		"ts")
 	assertTableColumns(t, tableName, [][]string{
 		{"i", "Nullable(Int32)", ""},
 		{"ts", "DateTime64(9, 'UTC')", ""},
-		{"_fivetran_synced", "DateTime64(9, 'UTC')", ""}})
+		{"_fivetran_synced", "DateTime64(9, 'UTC')", ""},
+		{"_fivetran_deleted", "Bool", ""}})
 }
 
 func TestNaiveDateTimePK(t *testing.T) {
@@ -129,12 +133,13 @@ func TestNaiveDateTimePK(t *testing.T) {
 	startServer(t)
 	runSDKTestCommand(t, fileName, true)
 	assertTableRowsWithPKColumns(t, tableName, [][]string{
-		{"144", "2022-06-01 18:44:13"}},
+		{"144", "2022-06-01 18:44:13", "false"}},
 		"dt")
 	assertTableColumns(t, tableName, [][]string{
 		{"i", "Nullable(Int32)", ""},
 		{"dt", "DateTime64(0, 'UTC')", ""},
-		{"_fivetran_synced", "DateTime64(9, 'UTC')", ""}})
+		{"_fivetran_synced", "DateTime64(9, 'UTC')", ""},
+		{"_fivetran_deleted", "Bool", ""}})
 }
 
 func TestNaiveDatePK(t *testing.T) {
@@ -143,12 +148,13 @@ func TestNaiveDatePK(t *testing.T) {
 	startServer(t)
 	runSDKTestCommand(t, fileName, true)
 	assertTableRowsWithPKColumns(t, tableName, [][]string{
-		{"144", "2022-06-01"}},
+		{"144", "2022-06-01", "false"}},
 		"d")
 	assertTableColumns(t, tableName, [][]string{
 		{"i", "Nullable(Int32)", ""},
 		{"d", "Date32", ""},
-		{"_fivetran_synced", "DateTime64(9, 'UTC')", ""}})
+		{"_fivetran_synced", "DateTime64(9, 'UTC')", ""},
+		{"_fivetran_deleted", "Bool", ""}})
 }
 
 func TestCompositeFloatPK(t *testing.T) {
@@ -157,14 +163,15 @@ func TestCompositeFloatPK(t *testing.T) {
 	startServer(t)
 	runSDKTestCommand(t, fileName, true)
 	assertTableRowsWithPKColumns(t, tableName, [][]string{
-		{"144", "300.3", "3.3", "4.4"}},
+		{"144", "300.3", "3.3", "4.4", "false"}},
 		"dec, f32, f64")
 	assertTableColumns(t, tableName, [][]string{
 		{"i", "Nullable(Int32)", ""},
 		{"dec", "Decimal(10, 4)", ""},
 		{"f32", "Float32", ""},
 		{"f64", "Float64", ""},
-		{"_fivetran_synced", "DateTime64(9, 'UTC')", ""}})
+		{"_fivetran_synced", "DateTime64(9, 'UTC')", ""},
+		{"_fivetran_deleted", "Bool", ""}})
 }
 
 func TestStringPK(t *testing.T) {
@@ -173,12 +180,13 @@ func TestStringPK(t *testing.T) {
 	startServer(t)
 	runSDKTestCommand(t, fileName, true)
 	assertTableRowsWithPKColumns(t, tableName, [][]string{
-		{"144", "qaz"}},
+		{"144", "qaz", "false"}},
 		"s")
 	assertTableColumns(t, tableName, [][]string{
 		{"i", "Nullable(Int32)", ""},
 		{"s", "String", ""},
-		{"_fivetran_synced", "DateTime64(9, 'UTC')", ""}})
+		{"_fivetran_synced", "DateTime64(9, 'UTC')", ""},
+		{"_fivetran_deleted", "Bool", ""}})
 }
 
 func TestCompositePKWithBoolean(t *testing.T) {
@@ -187,12 +195,13 @@ func TestCompositePKWithBoolean(t *testing.T) {
 	startServer(t)
 	runSDKTestCommand(t, fileName, true)
 	assertTableRowsWithPKColumns(t, tableName, [][]string{
-		{"144", "3", "true"}}, "l, b")
+		{"144", "3", "true", "false"}}, "l, b")
 	assertTableColumns(t, tableName, [][]string{
 		{"i", "Nullable(Int32)", ""},
 		{"l", "Int64", ""},
 		{"b", "Bool", ""},
-		{"_fivetran_synced", "DateTime64(9, 'UTC')", ""}})
+		{"_fivetran_synced", "DateTime64(9, 'UTC')", ""},
+		{"_fivetran_deleted", "Bool", ""}})
 }
 
 func TestNonExistentRecordUpdatesAndDeletes(t *testing.T) {
@@ -201,11 +210,12 @@ func TestNonExistentRecordUpdatesAndDeletes(t *testing.T) {
 	startServer(t)
 	runSDKTestCommand(t, fileName, true)
 	assertTableRowsWithPK(t, tableName, [][]string{
-		{"1", "\\N"}})
+		{"1", "\\N", "false"}})
 	assertTableColumns(t, tableName, [][]string{
 		{"id", "Int32", ""},
 		{"name", "Nullable(String)", ""},
-		{"_fivetran_synced", "DateTime64(9, 'UTC')", ""}})
+		{"_fivetran_synced", "DateTime64(9, 'UTC')", ""},
+		{"_fivetran_deleted", "Bool", ""}})
 }
 
 func TestSoftTruncateBefore(t *testing.T) {
@@ -230,12 +240,13 @@ func TestHardTruncateBefore(t *testing.T) {
 	startServer(t)
 	runSDKTestCommand(t, fileName, true)
 	assertTableRowsWithPK(t, tableName, [][]string{
-		{"2", "bar"},
-		{"3", "qaz"}})
+		{"2", "bar", "false"},
+		{"3", "qaz", "false"}})
 	assertTableColumns(t, tableName, [][]string{
 		{"id", "Int32", ""},
 		{"name", "Nullable(String)", ""},
-		{"_fivetran_synced", "DateTime64(9, 'UTC')", ""}})
+		{"_fivetran_synced", "DateTime64(9, 'UTC')", ""},
+		{"_fivetran_deleted", "Bool", ""}})
 }
 
 func TestTableNotFound(t *testing.T) {
@@ -250,15 +261,16 @@ func TestChangePK(t *testing.T) {
 	startServer(t)
 	runSDKTestCommand(t, fileName, true)
 	assertTableRowsWithPKColumns(t, tableName, [][]string{
-		{"1", "200", "foo"},
-		{"2", "50", "bar"},
-		{"4", "20.5", "qaz"}},
+		{"1", "200", "foo", "false"},
+		{"2", "50", "bar", "false"},
+		{"4", "20.5", "qaz", "false"}},
 		"id, s")
 	assertTableColumns(t, tableName, [][]string{
 		{"id", "Int32", ""},
 		{"amount", "Nullable(Float32)", ""},
 		{"s", "String", ""}, // non-nullable, now a PK
-		{"_fivetran_synced", "DateTime64(9, 'UTC')", ""}})
+		{"_fivetran_synced", "DateTime64(9, 'UTC')", ""},
+		{"_fivetran_deleted", "Bool", ""}})
 }
 
 func TestDropPK(t *testing.T) {
@@ -267,15 +279,16 @@ func TestDropPK(t *testing.T) {
 	startServer(t)
 	runSDKTestCommand(t, fileName, true)
 	assertTableRowsWithPKColumns(t, tableName, [][]string{
-		{"1", "200", "foo"},
-		{"2", "50", "bar"},
-		{"4", "20.5", "qaz"}},
+		{"1", "200", "foo", "false"},
+		{"2", "50", "bar", "false"},
+		{"4", "20.5", "qaz", "false"}},
 		"id")
 	assertTableColumns(t, tableName, [][]string{
 		{"id", "Int32", ""},
 		{"amount", "Nullable(Float32)", ""},
 		{"s", "Nullable(String)", ""}, // was PK, now it is Nullable (as a non-PK column)
-		{"_fivetran_synced", "DateTime64(9, 'UTC')", ""}})
+		{"_fivetran_synced", "DateTime64(9, 'UTC')", ""},
+		{"_fivetran_deleted", "Bool", ""}})
 }
 
 func TestChangePKAndAllColumns(t *testing.T) {
@@ -284,14 +297,15 @@ func TestChangePKAndAllColumns(t *testing.T) {
 	startServer(t)
 	runSDKTestCommand(t, fileName, true)
 	assertTableRowsWithPKColumns(t, tableName, [][]string{
-		{"1", "foo"},
-		{"2", "bar"},
-		{"4", "qaz"}},
+		{"1", "foo", "false"},
+		{"2", "bar", "false"},
+		{"4", "qaz", "false"}},
 		"id")
 	assertTableColumns(t, tableName, [][]string{
 		{"id", "Int32", ""}, // the only PK now
 		{"s", "Nullable(String)", ""},
-		{"_fivetran_synced", "DateTime64(9, 'UTC')", ""}})
+		{"_fivetran_synced", "DateTime64(9, 'UTC')", ""},
+		{"_fivetran_deleted", "Bool", ""}})
 }
 
 func TestTruncateDateValues(t *testing.T) {
@@ -300,14 +314,15 @@ func TestTruncateDateValues(t *testing.T) {
 	startServer(t)
 	runSDKTestCommand(t, fileName, true)
 	assertTableRowsWithPK(t, tableName, [][]string{
-		{"1", "1900-01-01", "1900-01-01 00:00:00", "1900-01-01 00:00:00.000000000"},
-		{"2", "2299-12-31", "2262-04-11 23:47:16", "2262-04-11 23:47:16.000000000"}})
+		{"1", "1900-01-01", "1900-01-01 00:00:00", "1900-01-01 00:00:00.000000000", "false"},
+		{"2", "2299-12-31", "2262-04-11 23:47:16", "2262-04-11 23:47:16.000000000", "false"}})
 	assertTableColumns(t, tableName, [][]string{
 		{"id", "Int32", ""},
 		{"d", "Nullable(Date32)", ""},
 		{"dt", "Nullable(DateTime64(0, 'UTC'))", ""},
 		{"utc", "Nullable(DateTime64(9, 'UTC'))", ""},
-		{"_fivetran_synced", "DateTime64(9, 'UTC')", ""}})
+		{"_fivetran_synced", "DateTime64(9, 'UTC')", ""},
+		{"_fivetran_deleted", "Bool", ""}})
 }
 
 func TestLargeInputFile(t *testing.T) {


### PR DESCRIPTION
## Summary
Related to https://github.com/ClickHouse/clickhouse-fivetran-destination/issues/85

- Update sdk tester version. It's needed for new schema_migrations files. Small issue: it adds the _fivetran_deleted column to all tables even the ones that don't need it, so we need to adjust some tests.
- Creates a new single MaxDateTime64 value instead of having this magic number replicated everywhere
