### PR TITLE
Add new sdk tests file for ddl migrations

### DIFF
--- a/destination/main_e2e_test.go
+++ b/destination/main_e2e_test.go
@@ -371,6 +371,33 @@ func TestHistoryMode(t *testing.T) {
 		{"5", "name 5", "TODO", "2025-11-10 20:57:00.000000000", "2262-04-11 23:47:16.000000000", "true"}}, dbRecordsCSVStr)
 }
 
+
+func TestSchemaMigrationsDDL(t *testing.T) {
+	fileName := "schema_migrations_input_ddl.json"
+	tableName := "transaction"
+	startServer(t)
+	runSDKTestCommand(t, fileName, true)
+	// After DDL migrations: add_column (operation_time UTC_DATETIME), change_column_data_type (amount DOUBLE->FLOAT), drop_column (desc)
+	assertTableColumns(t, tableName, [][]string{
+		{"id", "Int32", ""},
+		{"amount", "Nullable(Float32)", ""},
+		{"_fivetran_synced", "DateTime64(9, 'UTC')", ""},
+		{"_fivetran_deleted", "Bool", ""},
+		{"operation_time", "Nullable(DateTime64(9, 'UTC'))", ""}})
+
+	// Verify data: amounts were cast from Float64 to Float32, desc column was dropped, operation_time is NULL (added without default)
+	query := "SELECT * EXCEPT _fivetran_synced FROM tester.transaction FINAL ORDER BY id FORMAT CSV SETTINGS select_sequential_consistency=1"
+	dbRecordsCSVStr := runQuery(t, query)
+	assertDatabaseRecords(t, [][]string{
+		{"1", "100.45", "false", "\\N"},
+		{"2", "150.33", "false", "\\N"},
+		{"3", "150.33", "false", "\\N"},
+		{"4", "150.33", "false", "\\N"},
+		{"10", "200", "false", "\\N"},
+		{"20", "50", "false", "\\N"},
+	}, dbRecordsCSVStr)
+}
+
 // fail on the first mismatch, to prevent long console output
 func assertDatabaseRecordsFailFast(t *testing.T, expectedRecords [][]string, dbRecordsCSVStr string) {
 	csvReader := csv.NewReader(strings.NewReader(dbRecordsCSVStr))

--- a/sdk_tests/schema_migrations_input_ddl.json
+++ b/sdk_tests/schema_migrations_input_ddl.json
@@ -1,0 +1,53 @@
+{
+  "create_table" : {
+    "transaction": {
+      "columns": {
+        "id": "INT",
+        "amount": "DOUBLE",
+        "desc": "STRING"
+      },
+      "primary_key": ["id"]
+    }
+  },
+  "ops" : [
+    {
+      "upsert": {
+        "transaction": [
+          {"id":1, "amount": 100.45, "desc": null},
+          {"id":2, "amount": 150.33, "desc": "two"},
+          {"id":3, "amount": 150.33, "desc": "two"},
+          {"id":4, "amount": 150.33, "desc": "two"},
+          {"id":10, "amount": 200, "desc": "three"},
+          {"id":20, "amount": 50, "desc": "money"}
+        ]
+      }
+    }
+  ],
+  "schema_migration" : [
+    {
+      "add_column": [
+        {
+          "table": "transaction",
+          "column": "operation_time",
+          "data_type": "UTC_DATETIME"
+        }
+      ],
+      "change_column_data_type": [
+        {
+          "table": "transaction",
+          "column": "amount",
+          "data_type": "FLOAT"
+        }
+      ],
+      "drop_column": [
+        {
+          "table": "transaction",
+          "column": "desc"
+        }
+      ]
+    }
+  ],
+  "describe_table" : [
+    "transaction"
+  ]
+}


### PR DESCRIPTION
## Summary
Related to https://github.com/ClickHouse/clickhouse-fivetran-destination/issues/85

Added this file from Fivetran to increase or test coverage but this one doesn't need further changes, these migrations are already implemented as part of the AlterTable RPC commands.

Further testing of these migrations are already implemented in the main_e2e_test.go file.