### PR TITLE
Reduce logs overhead. Change it to a more idiomatic Go

### DIFF
--- a/destination/common/benchmark/bench.go
+++ b/destination/common/benchmark/bench.go
@@ -11,22 +11,20 @@ func RunAndNotice(op func() error, opName string) error {
 	start := time.Now()
 	err := op()
 	elapsed := time.Since(start) / time.Millisecond
-	if err == nil {
-		log.Notice(fmt.Sprintf("%s completed in %d ms", opName, elapsed))
-	} else {
-		err = fmt.Errorf("%s failed after %d ms: %w", opName, elapsed, err)
+	if err != nil {
+		return fmt.Errorf("%s failed after %d ms: %w", opName, elapsed, err)
 	}
-	return err
+	log.Notice(fmt.Sprintf("%s completed in %d ms", opName, elapsed))
+	return nil
 }
 
 func RunAndNoticeWithData[T any](op func() (T, error), opName string) (T, error) {
 	start := time.Now()
 	data, err := op()
 	elapsed := time.Since(start) / time.Millisecond
-	if err == nil {
-		log.Notice(fmt.Sprintf("%s completed in %d ms", opName, elapsed))
-	} else {
-		err = fmt.Errorf("%s failed after %d ms: %w", opName, elapsed, err)
+	if err != nil {
+		return data, fmt.Errorf("%s failed after %d ms: %w", opName, elapsed, err)
 	}
-	return data, err
+	log.Notice(fmt.Sprintf("%s completed in %d ms", opName, elapsed))
+	return data, nil
 }

--- a/destination/common/benchmark/bench.go
+++ b/destination/common/benchmark/bench.go
@@ -14,7 +14,7 @@ func RunAndNotice(op func() error, opName string) error {
 	if err == nil {
 		log.Notice(fmt.Sprintf("%s completed in %d ms", opName, elapsed))
 	} else {
-		log.Notice(fmt.Sprintf("%s failed after %d ms: %s", opName, elapsed, err))
+		err = fmt.Errorf("%s failed after %d ms: %w", opName, elapsed, err)
 	}
 	return err
 }
@@ -26,7 +26,7 @@ func RunAndNoticeWithData[T any](op func() (T, error), opName string) (T, error)
 	if err == nil {
 		log.Notice(fmt.Sprintf("%s completed in %d ms", opName, elapsed))
 	} else {
-		log.Notice(fmt.Sprintf("%s failed after %d ms: %s", opName, elapsed, err))
+		err = fmt.Errorf("%s failed after %d ms: %w", opName, elapsed, err)
 	}
 	return data, err
 }

--- a/destination/db/clickhouse.go
+++ b/destination/db/clickhouse.go
@@ -115,17 +115,13 @@ func GetClickHouseConnection(ctx context.Context, connConfig *config.Config) (*C
 	}
 	conn, err := clickhouse.Open(options)
 	if err != nil {
-		err = fmt.Errorf("error while opening a connection to ClickHouse: %w", err)
-		log.Error(err)
-		return nil, err
+		return nil, fmt.Errorf("error while opening a connection to ClickHouse: %w", err)
 	}
 	err = retry.OnNetError(func() error {
 		return conn.Ping(ctx)
 	}, ctx, "ping", false)
 	if err != nil {
-		err = fmt.Errorf("ClickHouse connection error: %w", err)
-		log.Error(err)
-		return nil, err
+		return nil, fmt.Errorf("ClickHouse connection error: %w", err)
 	}
 	log.Info("ClickHouse connection established successfully")
 	return &ClickHouseConnection{Conn: conn, username: connConfig.Username, isLocal: connConfig.Local}, nil
@@ -161,9 +157,7 @@ func (conn *ClickHouseConnection) ExecStatement(
 	conn.recordQuery(duration, err == nil)
 
 	if err != nil {
-		err = fmt.Errorf("error while executing %s [query_id=%s]: %w", statement, queryID, err)
-		log.Error(err)
-		return err
+		return fmt.Errorf("error while executing %s [query_id=%s]: %w", logQuery, queryID, err)
 	}
 	log.Info(fmt.Sprintf("Successfully executed %s [query_id=%s] in %v", op, queryID, duration))
 	return nil
@@ -199,9 +193,7 @@ func (conn *ClickHouseConnection) ExecQuery(
 	conn.recordQuery(duration, err == nil)
 
 	if err != nil {
-		err = fmt.Errorf("error while executing %s [query_id=%s]: %w", query, queryID, err)
-		log.Error(err)
-		return nil, err
+		return nil, fmt.Errorf("error while executing %s [query_id=%s]: %w", logQuery, queryID, err)
 	}
 	log.Info(fmt.Sprintf("Query %s [query_id=%s] completed in %v", op, queryID, duration))
 	return rows, nil
@@ -542,12 +534,9 @@ func (conn *ClickHouseConnection) InsertBatch(
 		batch, err := conn.PrepareBatch(ctx, fmt.Sprintf("INSERT INTO %s", qualifiedTableName))
 		if err != nil {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				err = fmt.Errorf("error while preparing batch for %s: %w (context state: %v)", qualifiedTableName, err, ctx.Err())
-			} else {
-				err = fmt.Errorf("error while preparing batch for %s: %w", qualifiedTableName, err)
+				return fmt.Errorf("error while preparing batch for %s: %w (context state: %v)", qualifiedTableName, err, ctx.Err())
 			}
-			log.Error(err)
-			return err
+			return fmt.Errorf("error while preparing batch for %s: %w", qualifiedTableName, err)
 		}
 		for i, row := range rows {
 			if skipIdx[i] {
@@ -556,23 +545,17 @@ func (conn *ClickHouseConnection) InsertBatch(
 			err = batch.Append(row...)
 			if err != nil {
 				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-					err = fmt.Errorf("error appending row to a batch for %s: %w (context state: %v)", qualifiedTableName, err, ctx.Err())
-				} else {
-					err = fmt.Errorf("error appending row to a batch for %s: %w", qualifiedTableName, err)
+					return fmt.Errorf("error appending row to a batch for %s: %w (context state: %v)", qualifiedTableName, err, ctx.Err())
 				}
-				log.Error(err)
-				return err
+				return fmt.Errorf("error appending row to a batch for %s: %w", qualifiedTableName, err)
 			}
 		}
 		err = batch.Send()
 		if err != nil {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				err = fmt.Errorf("error while sending batch for %s: %w (context state: %v)", qualifiedTableName, err, ctx.Err())
-			} else {
-				err = fmt.Errorf("error while sending batch for %s: %w", qualifiedTableName, err)
+				return fmt.Errorf("error while sending batch for %s: %w (context state: %v)", qualifiedTableName, err, ctx.Err())
 			}
-			log.Error(err)
-			return err
+			return fmt.Errorf("error while sending batch for %s: %w", qualifiedTableName, err)
 		}
 		return nil
 	}, ctx, opName, true)

--- a/destination/service/responses.go
+++ b/destination/service/responses.go
@@ -3,7 +3,6 @@ package service
 import (
 	"fmt"
 
-	"fivetran.com/fivetran_sdk/destination/common/log"
 	"fivetran.com/fivetran_sdk/destination/db/config"
 	pb "fivetran.com/fivetran_sdk/proto"
 )
@@ -83,7 +82,6 @@ func GetConfigurationFormResponse() *pb.ConfigurationFormResponse {
 }
 
 func FailedWriteBatchResponse(schemaName string, tableName string, err error) *pb.WriteBatchResponse {
-	logError("WriteBatch", err)
 	return &pb.WriteBatchResponse{
 		Response: &pb.WriteBatchResponse_Task{
 			Task: toTask(fmt.Sprintf("Failed to write batch into `%s`.`%s`, cause: %s", schemaName, tableName, err)),
@@ -92,7 +90,6 @@ func FailedWriteBatchResponse(schemaName string, tableName string, err error) *p
 }
 
 func FailedWriteHistoryBatchResponse(schemaName string, tableName string, err error) *pb.WriteBatchResponse {
-	logError("WriteHistoryBatch", err)
 	return &pb.WriteBatchResponse{
 		Response: &pb.WriteBatchResponse_Task{
 			Task: toTask(fmt.Sprintf("Failed to write history batch into `%s`.`%s`, cause: %s", schemaName, tableName, err)),
@@ -101,7 +98,6 @@ func FailedWriteHistoryBatchResponse(schemaName string, tableName string, err er
 }
 
 func FailedDescribeTableResponse(schemaName string, tableName string, err error) *pb.DescribeTableResponse {
-	logError("DescribeTable", err)
 	return &pb.DescribeTableResponse{
 		Response: &pb.DescribeTableResponse_Task{
 			Task: toTask(fmt.Sprintf("Failed to describe table `%s`.`%s`, cause: %s", schemaName, tableName, err)),
@@ -116,7 +112,6 @@ func NotFoundDescribeTableResponse() *pb.DescribeTableResponse {
 }
 
 func FailedTestResponse(name string, err error) *pb.TestResponse {
-	logError("Test", err)
 	return &pb.TestResponse{
 		Response: &pb.TestResponse_Failure{
 			Failure: fmt.Sprintf("Test %s failed, cause: %s", name, err),
@@ -125,7 +120,6 @@ func FailedTestResponse(name string, err error) *pb.TestResponse {
 }
 
 func FailedCreateTableResponse(schemaName string, tableName string, err error) *pb.CreateTableResponse {
-	logError("CreateTable", err)
 	return &pb.CreateTableResponse{
 		Response: &pb.CreateTableResponse_Task{
 			Task: toTask(fmt.Sprintf("Failed to create table `%s`.`%s`, cause: %s", schemaName, tableName, err)),
@@ -134,7 +128,6 @@ func FailedCreateTableResponse(schemaName string, tableName string, err error) *
 }
 
 func FailedAlterTableResponse(schemaName string, tableName string, err error) *pb.AlterTableResponse {
-	logError("AlterTable", err)
 	return &pb.AlterTableResponse{
 		Response: &pb.AlterTableResponse_Task{
 			Task: toTask(fmt.Sprintf("Failed to alter table `%s`.`%s`, cause: %s", schemaName, tableName, err)),
@@ -151,16 +144,11 @@ func SuccessfulTruncateTableResponse() *pb.TruncateResponse {
 }
 
 func FailedTruncateTableResponse(schemaName string, tableName string, err error) *pb.TruncateResponse {
-	logError("TruncateTable", err)
 	return &pb.TruncateResponse{
 		Response: &pb.TruncateResponse_Task{
 			Task: toTask(fmt.Sprintf("Failed to truncate table `%s`.`%s`, cause: %s", schemaName, tableName, err)),
 		},
 	}
-}
-
-func logError(endpoint string, err error) {
-	log.Error(fmt.Errorf("%s failed: %w", endpoint, err))
 }
 
 func toTask(taskMessage string) *pb.Task {

--- a/destination/service/server.go
+++ b/destination/service/server.go
@@ -419,20 +419,17 @@ func (s *Server) processReplaceFiles(
 				if err := func() error {
 					reader, err := csvreader.NewCSVFileReader(replaceFile, in.Keys, compression, encryption)
 					if err != nil {
-						log.Error(fmt.Errorf("[%s] Failed to open CSV file %s: %w", writeBatchReplaceOp, replaceFile, err))
-						return err
+						return fmt.Errorf("[%s] Failed to open CSV file %s: %w", writeBatchReplaceOp, replaceFile, err)
 					}
 					defer reader.Close()
 					csvColumns, err := types.MakeCSVColumns(reader.Header(), driverColumns, metadata.ColumnsMap, true)
 					if err != nil {
-						log.Error(fmt.Errorf("[%s] Failed to make CSV columns for file %s: %w", writeBatchReplaceOp, replaceFile, err))
-						return err
+						return fmt.Errorf("[%s] Failed to make CSV columns for file %s: %w", writeBatchReplaceOp, replaceFile, err)
 					}
 					log.Notice(fmt.Sprintf("[%s] Executing ReplaceBatch for %s.%s", writeBatchReplaceOp, in.SchemaName, in.Table.Name))
 					totalRows, err := conn.ReplaceBatch(ctx, in.SchemaName, in.Table, reader, csvColumns, nullStr)
 					if err != nil {
-						log.Error(fmt.Errorf("[%s] ReplaceBatch failed for %s.%s: %w", writeBatchReplaceOp, in.SchemaName, in.Table.Name, err))
-						return err
+						return fmt.Errorf("[%s] ReplaceBatch failed for %s.%s: %w", writeBatchReplaceOp, in.SchemaName, in.Table.Name, err)
 					}
 					if totalRows == 0 {
 						logEmptyCSV(&emptyCSVWarnParams{
@@ -477,34 +474,29 @@ func (s *Server) processEarliestStartFilesForHistoryBatch(
 					// First pass: hard delete overlapping records
 					deleteReader, err := csvreader.NewCSVFileReader(earliestStartFile, in.Keys, compression, encryption)
 					if err != nil {
-						log.Error(fmt.Errorf("[%s] Failed to open CSV file %s: %w", writeHistoryBatchEarliestStartOp, earliestStartFile, err))
-						return err
+						return fmt.Errorf("[%s] Failed to open CSV file %s: %w", writeHistoryBatchEarliestStartOp, earliestStartFile, err)
 					}
 					defer deleteReader.Close()
 					csvColumns, err := types.MakeCSVColumns(deleteReader.Header(), driverColumns, metadata.ColumnsMap, false)
 					if err != nil {
-						log.Error(fmt.Errorf("[%s] Failed to make CSV columns for file %s: %w", writeHistoryBatchEarliestStartOp, earliestStartFile, err))
-						return err
+						return fmt.Errorf("[%s] Failed to make CSV columns for file %s: %w", writeHistoryBatchEarliestStartOp, earliestStartFile, err)
 					}
 					log.Notice(fmt.Sprintf("[%s] Executing HardDeleteForEarliestStartHistory for %s.%s", writeHistoryBatchEarliestStartOp, in.SchemaName, in.Table.Name))
 					deleteRows, err := conn.HardDeleteForEarliestStartHistory(ctx, in.SchemaName, in.Table, deleteReader, csvColumns)
 					if err != nil {
-						log.Error(fmt.Errorf("[%s] HardDeleteForEarliestStartHistory failed for %s.%s: %w", writeHistoryBatchEarliestStartOp, in.SchemaName, in.Table.Name, err))
-						return err
+						return fmt.Errorf("[%s] HardDeleteForEarliestStartHistory failed for %s.%s: %w", writeHistoryBatchEarliestStartOp, in.SchemaName, in.Table.Name, err)
 					}
 
 					// Second pass: update active records
 					updateReader, err := csvreader.NewCSVFileReader(earliestStartFile, in.Keys, compression, encryption)
 					if err != nil {
-						log.Error(fmt.Errorf("[%s] Failed to open CSV file %s: %w", writeHistoryBatchEarliestStartOp, earliestStartFile, err))
-						return err
+						return fmt.Errorf("[%s] Failed to open CSV file %s: %w", writeHistoryBatchEarliestStartOp, earliestStartFile, err)
 					}
 					defer updateReader.Close()
 					log.Notice(fmt.Sprintf("[%s] Executing UpdateForEarliestStartHistory for %s.%s", writeHistoryBatchEarliestStartOp, in.SchemaName, in.Table.Name))
 					updateRows, err := conn.UpdateForEarliestStartHistory(ctx, in.SchemaName, in.Table, updateReader, csvColumns, constants.FivetranStart)
 					if err != nil {
-						log.Error(fmt.Errorf("[%s] UpdateForEarliestStartHistory failed for %s.%s: %w", writeHistoryBatchEarliestStartOp, in.SchemaName, in.Table.Name, err))
-						return err
+						return fmt.Errorf("[%s] UpdateForEarliestStartHistory failed for %s.%s: %w", writeHistoryBatchEarliestStartOp, in.SchemaName, in.Table.Name, err)
 					}
 
 					totalRows := deleteRows + updateRows
@@ -551,20 +543,17 @@ func (s *Server) processReplaceFilesForHistoryBatch(
 				if err := func() error {
 					reader, err := csvreader.NewCSVFileReader(replaceFile, in.Keys, compression, encryption)
 					if err != nil {
-						log.Error(fmt.Errorf("[%s] Failed to open CSV file %s: %w", writeHistoryBatchReplaceOp, replaceFile, err))
-						return err
+						return fmt.Errorf("[%s] Failed to open CSV file %s: %w", writeHistoryBatchReplaceOp, replaceFile, err)
 					}
 					defer reader.Close()
 					csvColumns, err := types.MakeCSVColumns(reader.Header(), driverColumns, metadata.ColumnsMap, true)
 					if err != nil {
-						log.Error(fmt.Errorf("[%s] Failed to make CSV columns for file %s: %w", writeHistoryBatchReplaceOp, replaceFile, err))
-						return err
+						return fmt.Errorf("[%s] Failed to make CSV columns for file %s: %w", writeHistoryBatchReplaceOp, replaceFile, err)
 					}
 					log.Notice(fmt.Sprintf("[%s] Executing ReplaceBatch for %s.%s", writeHistoryBatchReplaceOp, in.SchemaName, in.Table.Name))
 					totalRows, err := conn.ReplaceBatch(ctx, in.SchemaName, in.Table, reader, csvColumns, nullStr)
 					if err != nil {
-						log.Error(fmt.Errorf("[%s] ReplaceBatch failed for %s.%s: %w", writeHistoryBatchReplaceOp, in.SchemaName, in.Table.Name, err))
-						return err
+						return fmt.Errorf("[%s] ReplaceBatch failed for %s.%s: %w", writeHistoryBatchReplaceOp, in.SchemaName, in.Table.Name, err)
 					}
 					if totalRows == 0 {
 						logEmptyCSV(&emptyCSVWarnParams{
@@ -610,20 +599,17 @@ func (s *Server) processUpdateFiles(
 				if err := func() error {
 					reader, err := csvreader.NewCSVFileReader(updateFile, in.Keys, compression, encryption)
 					if err != nil {
-						log.Error(fmt.Errorf("[%s] Failed to open CSV file %s: %w", writeBatchUpdateOp, updateFile, err))
-						return err
+						return fmt.Errorf("[%s] Failed to open CSV file %s: %w", writeBatchUpdateOp, updateFile, err)
 					}
 					defer reader.Close()
 					csvColumns, err := types.MakeCSVColumns(reader.Header(), driverColumns, metadata.ColumnsMap, true)
 					if err != nil {
-						log.Error(fmt.Errorf("[%s] Failed to make CSV columns for file %s: %w", writeBatchUpdateOp, updateFile, err))
-						return err
+						return fmt.Errorf("[%s] Failed to make CSV columns for file %s: %w", writeBatchUpdateOp, updateFile, err)
 					}
 					log.Notice(fmt.Sprintf("[%s] Executing UpdateBatch for %s.%s", writeBatchUpdateOp, in.SchemaName, in.Table.Name))
 					totalRows, err := conn.UpdateBatch(ctx, in.SchemaName, in.Table, driverColumns, csvColumns, reader, nullStr, unmodifiedStr, false)
 					if err != nil {
-						log.Error(fmt.Errorf("[%s] UpdateBatch failed for %s.%s: %w", writeBatchUpdateOp, in.SchemaName, in.Table.Name, err))
-						return err
+						return fmt.Errorf("[%s] UpdateBatch failed for %s.%s: %w", writeBatchUpdateOp, in.SchemaName, in.Table.Name, err)
 					}
 					if totalRows == 0 {
 						logEmptyCSV(&emptyCSVWarnParams{
@@ -669,20 +655,17 @@ func (s *Server) processUpdateFilesForHistoryBatch(
 				if err := func() error {
 					reader, err := csvreader.NewCSVFileReader(updateFile, in.Keys, compression, encryption)
 					if err != nil {
-						log.Error(fmt.Errorf("[%s] Failed to open CSV file %s: %w", writeHistoryBatchUpdateOp, updateFile, err))
-						return err
+						return fmt.Errorf("[%s] Failed to open CSV file %s: %w", writeHistoryBatchUpdateOp, updateFile, err)
 					}
 					defer reader.Close()
 					csvColumns, err := types.MakeCSVColumns(reader.Header(), driverColumns, metadata.ColumnsMap, true)
 					if err != nil {
-						log.Error(fmt.Errorf("[%s] Failed to make CSV columns for file %s: %w", writeHistoryBatchUpdateOp, updateFile, err))
-						return err
+						return fmt.Errorf("[%s] Failed to make CSV columns for file %s: %w", writeHistoryBatchUpdateOp, updateFile, err)
 					}
 					log.Notice(fmt.Sprintf("[%s] Executing UpdateBatch for %s.%s", writeHistoryBatchUpdateOp, in.SchemaName, in.Table.Name))
 					totalRows, err := conn.UpdateBatch(ctx, in.SchemaName, in.Table, driverColumns, csvColumns, reader, nullStr, unmodifiedStr, true)
 					if err != nil {
-						log.Error(fmt.Errorf("[%s] UpdateBatch failed for %s.%s: %w", writeHistoryBatchUpdateOp, in.SchemaName, in.Table.Name, err))
-						return err
+						return fmt.Errorf("[%s] UpdateBatch failed for %s.%s: %w", writeHistoryBatchUpdateOp, in.SchemaName, in.Table.Name, err)
 					}
 					if totalRows == 0 {
 						logEmptyCSV(&emptyCSVWarnParams{
@@ -726,20 +709,17 @@ func (s *Server) processDeleteFiles(
 				if err := func() error {
 					reader, err := csvreader.NewCSVFileReader(deleteFile, in.Keys, compression, encryption)
 					if err != nil {
-						log.Error(fmt.Errorf("[%s] Failed to open CSV file %s: %w", writeBatchDeleteOp, deleteFile, err))
-						return err
+						return fmt.Errorf("[%s] Failed to open CSV file %s: %w", writeBatchDeleteOp, deleteFile, err)
 					}
 					defer reader.Close()
 					csvColumns, err := types.MakeCSVColumns(reader.Header(), driverColumns, metadata.ColumnsMap, true)
 					if err != nil {
-						log.Error(fmt.Errorf("[%s] Failed to make CSV columns for file %s: %w", writeBatchDeleteOp, deleteFile, err))
-						return err
+						return fmt.Errorf("[%s] Failed to make CSV columns for file %s: %w", writeBatchDeleteOp, deleteFile, err)
 					}
 					log.Notice(fmt.Sprintf("[%s] Executing HardDelete for %s.%s", writeBatchDeleteOp, in.SchemaName, in.Table.Name))
 					totalRows, err := conn.HardDelete(ctx, in.SchemaName, in.Table, reader, csvColumns)
 					if err != nil {
-						log.Error(fmt.Errorf("[%s] HardDelete failed for %s.%s: %w", writeBatchDeleteOp, in.SchemaName, in.Table.Name, err))
-						return err
+						return fmt.Errorf("[%s] HardDelete failed for %s.%s: %w", writeBatchDeleteOp, in.SchemaName, in.Table.Name, err)
 					}
 					if totalRows == 0 {
 						logEmptyCSV(&emptyCSVWarnParams{
@@ -783,20 +763,17 @@ func (s *Server) processDeleteFilesForHistoryBatch(
 				if err := func() error {
 					reader, err := csvreader.NewCSVFileReader(deleteFile, in.Keys, compression, encryption)
 					if err != nil {
-						log.Error(fmt.Errorf("[%s] Failed to open CSV file %s: %w", writeHistoryBatchDeleteOp, deleteFile, err))
-						return err
+						return fmt.Errorf("[%s] Failed to open CSV file %s: %w", writeHistoryBatchDeleteOp, deleteFile, err)
 					}
 					defer reader.Close()
 					csvColumns, err := types.MakeCSVColumns(reader.Header(), driverColumns, metadata.ColumnsMap, false)
 					if err != nil {
-						log.Error(fmt.Errorf("[%s] Failed to make CSV columns for file %s: %w", writeHistoryBatchDeleteOp, deleteFile, err))
-						return err
+						return fmt.Errorf("[%s] Failed to make CSV columns for file %s: %w", writeHistoryBatchDeleteOp, deleteFile, err)
 					}
 					log.Notice(fmt.Sprintf("[%s] Executing UpdateForEarliestStartHistory for %s.%s", writeHistoryBatchDeleteOp, in.SchemaName, in.Table.Name))
 					totalRows, err := conn.UpdateForEarliestStartHistory(ctx, in.SchemaName, in.Table, reader, csvColumns, constants.FivetranEnd)
 					if err != nil {
-						log.Error(fmt.Errorf("[%s] UpdateForEarliestStartHistory failed for %s.%s: %w", writeHistoryBatchDeleteOp, in.SchemaName, in.Table.Name, err))
-						return err
+						return fmt.Errorf("[%s] UpdateForEarliestStartHistory failed for %s.%s: %w", writeHistoryBatchDeleteOp, in.SchemaName, in.Table.Name, err)
 					}
 					if totalRows == 0 {
 						logEmptyCSV(&emptyCSVWarnParams{


### PR DESCRIPTION
## Summary
Closes https://github.com/ClickHouse/clickhouse-fivetran-destination/issues/90

The issue is that we repeated logs for some errors as we log it in each function where the error passes. I'm used to just print the stacktrace in Python, but as I'm learning, in Go it's more common to handle the error (do printing it would be considered handling) or just add context and return it [1].

So the idea is to get rid of situations like an error inside the `ExecStatement` function as that error may get printed 7 times as it passed from one function to another.

I have also reduced the sql size we print in the `ExecStatement` in case of error as that sql may contain up to 262144 B of size and we usually reach that size when doing deletes/updates.

[1] By Claude:
```
1. Dave Cheney -- "Let's talk about logging" (2015) https://dave.cheney.net/2015/11/05/lets-talk-about-logging

This is the most direct and widely-cited source. Dave Cheney (a core Go community figure). He frames logging as a form of handling -- so if you log AND return, you've handled the error twice. He explicitly states:

"If you choose to handle the error by logging it, by definition it's not an error any more -- you handled it. The act of logging an error handles the error, hence it is no longer appropriate to log it as an error."

2. Dave Cheney -- "Don't just check errors, handle them gracefully" (GothamGo 2016 talk + blog post) https://dave.cheney.net/2016/04/27/dont-just-check-errors-handle-them-gracefully

This is a conference talk (also a blog post) where he elaborates on the principle with practical patterns. He recommends wrapping errors with context via fmt.Errorf and letting them bubble up to a single handling point.
```