### PR TITLE
keep lint cache to reduce runtime from 13s to 3s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ recreate-test-db:
 	curl --data-binary "CREATE DATABASE tester" http://localhost:8123
 
 lint:
-	docker run --rm -v $$PWD:/destination -w /destination golangci/golangci-lint:$(GOLANG_CI_LINT_VERSION) golangci-lint run -v
+	docker run --rm -v $$PWD:/destination -v golangci-lint-cache:/root/.cache -w /destination golangci/golangci-lint:$(GOLANG_CI_LINT_VERSION) golangci-lint run -v
 
 test:
 	test -f sdk_tests/configuration.json || cp sdk_tests/default_configuration.json sdk_tests/configuration.json


### PR DESCRIPTION
golangci-lint caches data so next execution will be faster. With this we make golangci-lint in docker speedup from 13s to 3s
