### PR TITLE
Reduce tests flakiness

### DIFF
--- a/destination/db/clickhouse.go
+++ b/destination/db/clickhouse.go
@@ -75,18 +75,19 @@ func GetClickHouseConnection(ctx context.Context, connConfig *config.Config) (*C
 		// support ISO DateTime formats from CSV
 		// https://clickhouse.com/docs/en/operations/settings/formats#date_time_input_format
 		"date_time_input_format": "best_effort",
+		// https://clickhouse.com/docs/en/operations/settings/settings#alter-sync
+		// https://github.com/ClickHouse/clickhouse-private/pull/12617
+		"alter_sync": 3,
+		// https://clickhouse.com/docs/en/operations/settings/settings#mutations_sync
+		// https://github.com/ClickHouse/clickhouse-private/pull/12617
+		"mutations_sync": 3,
+		// https://clickhouse.com/docs/en/operations/settings/settings#lightweight_deletes_sync
+		"lightweight_deletes_sync": 3,
 	}
 	var tlsConfig *tls.Config = nil
 	if !connConfig.Local {
 		tlsConfig = &tls.Config{InsecureSkipVerify: false}
-		// https://clickhouse.com/docs/en/operations/settings/settings#alter-sync
-		// https://github.com/ClickHouse/clickhouse-private/pull/12617
-		settings["alter_sync"] = 3
-		// https://clickhouse.com/docs/en/operations/settings/settings#mutations_sync
-		// https://github.com/ClickHouse/clickhouse-private/pull/12617
-		settings["mutations_sync"] = 3
-		// https://clickhouse.com/docs/en/operations/settings/settings#lightweight_deletes_sync
-		settings["lightweight_deletes_sync"] = 3
+
 		// https://clickhouse.com/docs/en/operations/settings/settings#select_sequential_consistency
 		settings["select_sequential_consistency"] = 1
 	}

--- a/destination/main_e2e_test.go
+++ b/destination/main_e2e_test.go
@@ -610,7 +610,7 @@ func waitPortIsReady(t *testing.T, port uint) {
 
 func runSDKTestCommand(t *testing.T, inputFileName string, recreateDatabase bool) {
 	if recreateDatabase {
-		runQuery(t, "DROP DATABASE IF EXISTS tester")
+		runQuery(t, "DROP DATABASE IF EXISTS tester SYNC")
 		runQuery(t, "CREATE DATABASE IF NOT EXISTS tester")
 	}
 	projectRootDir := getProjectRootDir(t)


### PR DESCRIPTION
Example of some of them
- https://github.com/ClickHouse/clickhouse-fivetran-destination/actions/runs/24708423360/job/72266946930
- https://github.com/ClickHouse/clickhouse-fivetran-destination/actions/runs/24708408377/job/72266899036

The majority of these errors came from the different fronts:
- Cloud instance instability (the env we use is a testing env).
- And resources/operations from one tests impacting into other tests, like the drop database operation being completed after the test have already started. <- This is what I'm trying to improve by adding sync to the drop database.

Apart from this, I'm also applying `alter_sync`, `mutations_sync` and `lightweight_deletes_sync` locally as some tests has failed because we weren't correctly waiting for some mutations to happen