### PR TITLE
Enable more linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,35 @@
 version: "2"
 
 linters:
+  enable:
+    # Tier 1: correctness / safety nets
+    - bodyclose
+    - contextcheck
+    - copyloopvar
+    - dupword
+    - durationcheck
+    - errname
+    - errorlint
+    - fatcontext
+    - gocheckcompilerdirectives
+    - mirror
+    - misspell
+    - nilerr
+    - nilnesserr
+    - predeclared
+    - reassign
+    - recvcheck
+    - rowserrcheck
+    - sqlclosecheck
+    - unconvert
+    - usestdlibvars
+    # Tier 2: moderate value, small cleanups
+    - gocritic
+    - intrange
+    - noctx
+    - prealloc
+    - unparam
+    - wastedassign
   settings:
     staticcheck:
       checks:

--- a/destination/cmd/start.go
+++ b/destination/cmd/start.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"net"
@@ -26,7 +27,8 @@ func StartServer() {
 		log.Error(fmt.Errorf("failed to initialize logger: %w", err))
 		os.Exit(1)
 	}
-	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", *flags.Port))
+	var lc net.ListenConfig
+	listener, err := lc.Listen(context.Background(), "tcp", fmt.Sprintf(":%d", *flags.Port))
 	if err != nil {
 		log.Error(fmt.Errorf("failed to listen: %w", err))
 		os.Exit(1)

--- a/destination/common/csv/csv_files.go
+++ b/destination/common/csv/csv_files.go
@@ -2,6 +2,7 @@ package csv
 
 import (
 	"encoding/csv"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -86,7 +87,7 @@ func NewCSVFileReader(
 	r.csvReader = csv.NewReader(decompressedReader)
 
 	header, err := r.csvReader.Read()
-	if err == io.EOF {
+	if errors.Is(err, io.EOF) {
 		r.Close()
 		return nil, fmt.Errorf("received an empty CSV file %s without a header", fileName)
 	}

--- a/destination/common/retry/retry.go
+++ b/destination/common/retry/retry.go
@@ -134,10 +134,10 @@ func OnFalseWithFixedDelay(
 
 func IsNetError(err error) bool {
 	var netErr net.Error
-	return errors.As(err, &netErr) || err == io.EOF || err.Error() == "EOF"
+	return errors.As(err, &netErr) || errors.Is(err, io.EOF) || err.Error() == "EOF"
 }
 
-func GetDelayConfig() (initial time.Duration, max time.Duration) {
+func GetDelayConfig() (initial time.Duration, maxDelay time.Duration) {
 	if *flags.InitialRetryDelayMilliseconds == 0 {
 		initial = time.Second
 	} else {

--- a/destination/common/retry/retry.go
+++ b/destination/common/retry/retry.go
@@ -144,7 +144,7 @@ func IsNetError(err error) bool {
 		return false
 	}
 	var netErr net.Error
-	return errors.As(err, &netErr) || errors.Is(err, io.EOF) || err.Error() == "EOF"
+	return errors.As(err, &netErr) || errors.Is(err, io.EOF)
 }
 
 func GetDelayConfig() (initial time.Duration, maxDelay time.Duration) {

--- a/destination/common/retry/retry.go
+++ b/destination/common/retry/retry.go
@@ -144,10 +144,10 @@ func IsNetError(err error) bool {
 		return false
 	}
 	var netErr net.Error
-	return errors.As(err, &netErr) || errors.Is(err, io.EOF)
+	return errors.As(err, &netErr) || errors.Is(err, io.EOF) || err.Error() == "EOF"
 }
 
-func GetDelayConfig() (initial time.Duration, max time.Duration) {
+func GetDelayConfig() (initial time.Duration, maxDelay time.Duration) {
 	if *flags.InitialRetryDelayMilliseconds == 0 {
 		initial = time.Second
 	} else {

--- a/destination/common/retry/retry_test.go
+++ b/destination/common/retry/retry_test.go
@@ -36,27 +36,27 @@ func TestGetRetryDelayConfig(t *testing.T) {
 
 	*flags.InitialRetryDelayMilliseconds = 0
 	*flags.MaxRetryDelayMilliseconds = 10
-	initial, max := GetDelayConfig()
+	initial, maxDelay := GetDelayConfig()
 	assert.Equal(t, time.Second, initial)
-	assert.Equal(t, time.Millisecond*10, max)
+	assert.Equal(t, time.Millisecond*10, maxDelay)
 
 	*flags.InitialRetryDelayMilliseconds = 50
 	*flags.MaxRetryDelayMilliseconds = 0
-	initial, max = GetDelayConfig()
+	initial, maxDelay = GetDelayConfig()
 	assert.Equal(t, time.Millisecond*50, initial)
-	assert.Equal(t, time.Millisecond*50, max)
+	assert.Equal(t, time.Millisecond*50, maxDelay)
 
 	*flags.InitialRetryDelayMilliseconds = 42
 	*flags.MaxRetryDelayMilliseconds = 144
-	initial, max = GetDelayConfig()
+	initial, maxDelay = GetDelayConfig()
 	assert.Equal(t, time.Millisecond*42, initial)
-	assert.Equal(t, time.Millisecond*144, max)
+	assert.Equal(t, time.Millisecond*144, maxDelay)
 
 	*flags.InitialRetryDelayMilliseconds = 144
 	*flags.MaxRetryDelayMilliseconds = 42
-	initial, max = GetDelayConfig()
+	initial, maxDelay = GetDelayConfig()
 	assert.Equal(t, time.Millisecond*144, initial)
-	assert.Equal(t, time.Millisecond*144, max)
+	assert.Equal(t, time.Millisecond*144, maxDelay)
 }
 
 func TestRetryNetError(t *testing.T) {

--- a/destination/common/retry/retry_test.go
+++ b/destination/common/retry/retry_test.go
@@ -58,27 +58,27 @@ func TestGetRetryDelayConfig(t *testing.T) {
 
 	*flags.InitialRetryDelayMilliseconds = 0
 	*flags.MaxRetryDelayMilliseconds = 10
-	initial, max := GetDelayConfig()
+	initial, maxDelay := GetDelayConfig()
 	assert.Equal(t, time.Second, initial)
-	assert.Equal(t, time.Millisecond*10, max)
+	assert.Equal(t, time.Millisecond*10, maxDelay)
 
 	*flags.InitialRetryDelayMilliseconds = 50
 	*flags.MaxRetryDelayMilliseconds = 0
-	initial, max = GetDelayConfig()
+	initial, maxDelay = GetDelayConfig()
 	assert.Equal(t, time.Millisecond*50, initial)
-	assert.Equal(t, time.Millisecond*50, max)
+	assert.Equal(t, time.Millisecond*50, maxDelay)
 
 	*flags.InitialRetryDelayMilliseconds = 42
 	*flags.MaxRetryDelayMilliseconds = 144
-	initial, max = GetDelayConfig()
+	initial, maxDelay = GetDelayConfig()
 	assert.Equal(t, time.Millisecond*42, initial)
-	assert.Equal(t, time.Millisecond*144, max)
+	assert.Equal(t, time.Millisecond*144, maxDelay)
 
 	*flags.InitialRetryDelayMilliseconds = 144
 	*flags.MaxRetryDelayMilliseconds = 42
-	initial, max = GetDelayConfig()
+	initial, maxDelay = GetDelayConfig()
 	assert.Equal(t, time.Millisecond*144, initial)
-	assert.Equal(t, time.Millisecond*144, max)
+	assert.Equal(t, time.Millisecond*144, maxDelay)
 }
 
 func TestRetryNetError(t *testing.T) {

--- a/destination/common/types/check_scan_types.go
+++ b/destination/common/types/check_scan_types.go
@@ -49,7 +49,7 @@ func CheckScanTypes(
 }
 
 func joinColNames[Value any](cols map[string]Value) string {
-	var names []string
+	names := make([]string, 0, len(cols))
 	for name := range cols {
 		names = append(names, name)
 	}

--- a/destination/db/clickhouse.go
+++ b/destination/db/clickhouse.go
@@ -535,7 +535,7 @@ func (conn *ClickHouseConnection) InsertBatch(
 		batch, err := conn.PrepareBatch(ctx, fmt.Sprintf("INSERT INTO %s", qualifiedTableName))
 		if err != nil {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				return fmt.Errorf("error while preparing batch for %s: %w (context state: %v)", qualifiedTableName, err, ctx.Err())
+				return fmt.Errorf("error while preparing batch for %s: %w (context state: %s)", qualifiedTableName, err, ctx.Err().Error())
 			}
 			return fmt.Errorf("error while preparing batch for %s: %w", qualifiedTableName, err)
 		}
@@ -546,7 +546,7 @@ func (conn *ClickHouseConnection) InsertBatch(
 			err = batch.Append(row...)
 			if err != nil {
 				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-					return fmt.Errorf("error appending row to a batch for %s: %w (context state: %v)", qualifiedTableName, err, ctx.Err())
+					return fmt.Errorf("error appending row to a batch for %s: %w (context state: %s)", qualifiedTableName, err, ctx.Err().Error())
 				}
 				return fmt.Errorf("error appending row to a batch for %s: %w", qualifiedTableName, err)
 			}
@@ -554,7 +554,7 @@ func (conn *ClickHouseConnection) InsertBatch(
 		err = batch.Send()
 		if err != nil {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				return fmt.Errorf("error while sending batch for %s: %w (context state: %v)", qualifiedTableName, err, ctx.Err())
+				return fmt.Errorf("error while sending batch for %s: %w (context state: %s)", qualifiedTableName, err, ctx.Err().Error())
 			}
 			return fmt.Errorf("error while sending batch for %s: %w", qualifiedTableName, err)
 		}

--- a/destination/db/clickhouse.go
+++ b/destination/db/clickhouse.go
@@ -535,7 +535,8 @@ func (conn *ClickHouseConnection) InsertBatch(
 		batch, err := conn.PrepareBatch(ctx, fmt.Sprintf("INSERT INTO %s", qualifiedTableName))
 		if err != nil {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				return fmt.Errorf("error while preparing batch for %s: %w (context state: %s)", qualifiedTableName, err, ctx.Err().Error())
+				// ctx.Err() is diagnostic context, not the primary error; %v is nil-safe.
+				return fmt.Errorf("error while preparing batch for %s: %w (context state: %v)", qualifiedTableName, err, ctx.Err()) //nolint:errorlint
 			}
 			return fmt.Errorf("error while preparing batch for %s: %w", qualifiedTableName, err)
 		}
@@ -546,7 +547,8 @@ func (conn *ClickHouseConnection) InsertBatch(
 			err = batch.Append(row...)
 			if err != nil {
 				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-					return fmt.Errorf("error appending row to a batch for %s: %w (context state: %s)", qualifiedTableName, err, ctx.Err().Error())
+					// ctx.Err() is diagnostic context, not the primary error; %v is nil-safe.
+					return fmt.Errorf("error appending row to a batch for %s: %w (context state: %v)", qualifiedTableName, err, ctx.Err()) //nolint:errorlint
 				}
 				return fmt.Errorf("error appending row to a batch for %s: %w", qualifiedTableName, err)
 			}
@@ -554,7 +556,8 @@ func (conn *ClickHouseConnection) InsertBatch(
 		err = batch.Send()
 		if err != nil {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				return fmt.Errorf("error while sending batch for %s: %w (context state: %s)", qualifiedTableName, err, ctx.Err().Error())
+				// ctx.Err() is diagnostic context, not the primary error; %v is nil-safe.
+				return fmt.Errorf("error while sending batch for %s: %w (context state: %v)", qualifiedTableName, err, ctx.Err()) //nolint:errorlint
 			}
 			return fmt.Errorf("error while sending batch for %s: %w", qualifiedTableName, err)
 		}

--- a/destination/db/slices.go
+++ b/destination/db/slices.go
@@ -46,16 +46,16 @@ func GroupSlices(fileLen uint, batchSize uint, maxParallelOperations uint) ([][]
 	if fileLen == 0 {
 		return nil, nil
 	}
-	groupsCount := uint(0)
+	var groupsCount uint
 	if fileLen%(batchSize*maxParallelOperations) > 0 {
 		groupsCount = (fileLen / batchSize / maxParallelOperations) + 1
 	} else {
 		groupsCount = fileLen / batchSize / maxParallelOperations
 	}
 	groups := make([][]Slice, groupsCount)
-	for i := uint(0); i < groupsCount; i++ {
+	for i := range groupsCount {
 		groups[i] = make([]Slice, 0, maxParallelOperations)
-		for j := uint(0); j < maxParallelOperations; j++ {
+		for j := range maxParallelOperations {
 			start := i*maxParallelOperations*batchSize + j*batchSize
 			if start >= fileLen {
 				break

--- a/destination/encryption/aes/aes.go
+++ b/destination/encryption/aes/aes.go
@@ -33,19 +33,19 @@ func (r *Decoder) Read(dest []byte) (readBytes int, err error) {
 	}
 	offset := 0
 	if len(r.buf) > 0 {
-		if len(dest) < len(r.buf) {
+		switch {
+		case len(dest) < len(r.buf):
 			copy(dest, r.buf[:len(dest)])
 			r.buf = r.buf[len(dest):]
 			return len(dest), nil
-		} else if len(dest) == len(r.buf) {
+		case len(dest) == len(r.buf):
 			copy(dest, r.buf)
 			r.buf = nil
 			if r.fileLen == 0 {
 				return len(dest), io.EOF
-			} else {
-				return len(dest), nil
 			}
-		} else {
+			return len(dest), nil
+		default:
 			offset = copy(dest, r.buf)
 			if r.fileLen == 0 {
 				return offset, io.EOF

--- a/destination/main_e2e_test.go
+++ b/destination/main_e2e_test.go
@@ -29,7 +29,7 @@ func TestAllDataTypes(t *testing.T) {
 	fileName := "input_all_data_types.json"
 	tableName := "all_data_types"
 	startServer(t)
-	runSDKTestCommand(t, fileName, true)
+	runSDKTestCommand(t, fileName)
 	assertTableRowsWithFivetranID(t, tableName, [][]string{
 		{"true", "42", "144", "100500", "100.5", "200.5", "42.42",
 			"2024-05-07", "2024-04-05 15:33:14", "2024-02-03 12:44:22.123456789",
@@ -62,7 +62,7 @@ func TestMutateAfterAlter(t *testing.T) {
 	fileName := "input_mutate_after_alter.json"
 	tableName := "mutate_after_alter"
 	startServer(t)
-	runSDKTestCommand(t, fileName, true)
+	runSDKTestCommand(t, fileName)
 	assertTableRowsWithPK(t, tableName, [][]string{
 		{"1", "200", "asd", "zxc", "\\N", "\\N", "false"},
 		{"2", "50", "\\N", "\\N", "<c>99</c>", "DD", "false"},
@@ -82,7 +82,7 @@ func TestUpdateAndHardDelete(t *testing.T) {
 	fileName := "input_update_and_hard_delete.json"
 	tableName := "update_and_delete"
 	startServer(t)
-	runSDKTestCommand(t, fileName, true)
+	runSDKTestCommand(t, fileName)
 	assertTableRowsWithPK(t, tableName, [][]string{
 		{"1", "1111", "false"},
 		{"2", "two", "false"}})
@@ -97,7 +97,7 @@ func TestSoftDelete(t *testing.T) {
 	fileName := "input_soft_delete.json"
 	tableName := "soft_delete_table"
 	startServer(t)
-	runSDKTestCommand(t, fileName, true)
+	runSDKTestCommand(t, fileName)
 	assertTableRowsWithPK(t, tableName, [][]string{
 		{"1", "\\N", "false"},
 		{"2", "two", "false"},
@@ -115,7 +115,7 @@ func TestUTCDateTimePrimaryKey(t *testing.T) {
 	fileName := "input_utc_datetime_pk.json"
 	tableName := "utc_datetime_pk"
 	startServer(t)
-	runSDKTestCommand(t, fileName, true)
+	runSDKTestCommand(t, fileName)
 	assertTableRowsWithPKColumns(t, tableName, [][]string{
 		{"144", "2024-01-14 15:13:12.000000000", "false"},
 		{"2", "2024-01-14 15:13:12.123000000", "false"}},
@@ -131,7 +131,7 @@ func TestNaiveDateTimePK(t *testing.T) {
 	fileName := "input_naive_datetime_pk.json"
 	tableName := "naive_datetime_pk"
 	startServer(t)
-	runSDKTestCommand(t, fileName, true)
+	runSDKTestCommand(t, fileName)
 	assertTableRowsWithPKColumns(t, tableName, [][]string{
 		{"144", "2022-06-01 18:44:13", "false"}},
 		"dt")
@@ -146,7 +146,7 @@ func TestNaiveDatePK(t *testing.T) {
 	fileName := "input_naive_date_pk.json"
 	tableName := "naive_date_pk"
 	startServer(t)
-	runSDKTestCommand(t, fileName, true)
+	runSDKTestCommand(t, fileName)
 	assertTableRowsWithPKColumns(t, tableName, [][]string{
 		{"144", "2022-06-01", "false"}},
 		"d")
@@ -161,7 +161,7 @@ func TestCompositeFloatPK(t *testing.T) {
 	fileName := "input_composite_floats_pk.json"
 	tableName := "composite_floats_pk"
 	startServer(t)
-	runSDKTestCommand(t, fileName, true)
+	runSDKTestCommand(t, fileName)
 	assertTableRowsWithPKColumns(t, tableName, [][]string{
 		{"144", "300.3", "3.3", "4.4", "false"}},
 		"dec, f32, f64")
@@ -178,7 +178,7 @@ func TestStringPK(t *testing.T) {
 	fileName := "input_string_pk.json"
 	tableName := "string_pk"
 	startServer(t)
-	runSDKTestCommand(t, fileName, true)
+	runSDKTestCommand(t, fileName)
 	assertTableRowsWithPKColumns(t, tableName, [][]string{
 		{"144", "qaz", "false"}},
 		"s")
@@ -193,7 +193,7 @@ func TestCompositePKWithBoolean(t *testing.T) {
 	fileName := "input_composite_pk_with_boolean.json"
 	tableName := "composite_pk_with_boolean"
 	startServer(t)
-	runSDKTestCommand(t, fileName, true)
+	runSDKTestCommand(t, fileName)
 	assertTableRowsWithPKColumns(t, tableName, [][]string{
 		{"144", "3", "true", "false"}}, "l, b")
 	assertTableColumns(t, tableName, [][]string{
@@ -208,7 +208,7 @@ func TestNonExistentRecordUpdatesAndDeletes(t *testing.T) {
 	fileName := "input_non_existent_updates.json"
 	tableName := "non_existent_updates"
 	startServer(t)
-	runSDKTestCommand(t, fileName, true)
+	runSDKTestCommand(t, fileName)
 	assertTableRowsWithPK(t, tableName, [][]string{
 		{"1", "\\N", "false"}})
 	assertTableColumns(t, tableName, [][]string{
@@ -222,7 +222,7 @@ func TestSoftTruncateBefore(t *testing.T) {
 	fileName := "input_soft_truncate_before.json"
 	tableName := "table_to_truncate"
 	startServer(t)
-	runSDKTestCommand(t, fileName, true)
+	runSDKTestCommand(t, fileName)
 	assertTableRowsWithPK(t, tableName, [][]string{
 		{"1", "foo", "true"},
 		{"2", "bar", "false"},
@@ -238,7 +238,7 @@ func TestHardTruncateBefore(t *testing.T) {
 	fileName := "input_hard_truncate_before.json"
 	tableName := "table_to_truncate"
 	startServer(t)
-	runSDKTestCommand(t, fileName, true)
+	runSDKTestCommand(t, fileName)
 	assertTableRowsWithPK(t, tableName, [][]string{
 		{"2", "bar", "false"},
 		{"3", "qaz", "false"}})
@@ -252,14 +252,14 @@ func TestHardTruncateBefore(t *testing.T) {
 func TestTableNotFound(t *testing.T) {
 	fileName := "input_table_not_found.json"
 	startServer(t)
-	runSDKTestCommand(t, fileName, true) // verify at least no SDK tester errors
+	runSDKTestCommand(t, fileName) // verify at least no SDK tester errors
 }
 
 func TestChangePK(t *testing.T) {
 	fileName := "input_change_pk.json"
 	tableName := "change_pk"
 	startServer(t)
-	runSDKTestCommand(t, fileName, true)
+	runSDKTestCommand(t, fileName)
 	assertTableRowsWithPKColumns(t, tableName, [][]string{
 		{"1", "200", "foo", "false"},
 		{"2", "50", "bar", "false"},
@@ -277,7 +277,7 @@ func TestDropPK(t *testing.T) {
 	fileName := "input_drop_pk.json"
 	tableName := "drop_pk"
 	startServer(t)
-	runSDKTestCommand(t, fileName, true)
+	runSDKTestCommand(t, fileName)
 	assertTableRowsWithPKColumns(t, tableName, [][]string{
 		{"1", "200", "foo", "false"},
 		{"2", "50", "bar", "false"},
@@ -295,7 +295,7 @@ func TestChangePKAndAllColumns(t *testing.T) {
 	fileName := "input_change_pk_and_all_columns.json"
 	tableName := "change_pk_and_all_columns"
 	startServer(t)
-	runSDKTestCommand(t, fileName, true)
+	runSDKTestCommand(t, fileName)
 	assertTableRowsWithPKColumns(t, tableName, [][]string{
 		{"1", "foo", "false"},
 		{"2", "bar", "false"},
@@ -312,7 +312,7 @@ func TestTruncateDateValues(t *testing.T) {
 	fileName := "input_truncate_date_values.json"
 	tableName := "truncate_date_values"
 	startServer(t)
-	runSDKTestCommand(t, fileName, true)
+	runSDKTestCommand(t, fileName)
 	assertTableRowsWithPK(t, tableName, [][]string{
 		{"1", "1900-01-01", "1900-01-01 00:00:00", "1900-01-01 00:00:00.000000000", "false"},
 		{"2", "2299-12-31", "2262-04-11 23:47:16", "2262-04-11 23:47:16.000000000", "false"}})
@@ -331,7 +331,7 @@ func TestLargeInputFile(t *testing.T) {
 	startServer(t)
 
 	expectedCSV := generateAndWriteInputFile(t, tableName, 150_000)
-	runSDKTestCommand(t, fmt.Sprintf("%s.json", tableName), true)
+	runSDKTestCommand(t, fmt.Sprintf("%s.json", tableName))
 
 	dbRecordsCSVStr := runQuery(t, fmt.Sprintf("SELECT * EXCEPT _fivetran_synced FROM tester.%s FINAL ORDER BY id FORMAT CSV", tableName))
 	assertDatabaseRecordsFailFast(t, expectedCSV, dbRecordsCSVStr)
@@ -346,7 +346,7 @@ func TestHistoryMode(t *testing.T) {
 	fileName := "input_history_mode.json"
 	tableName := "users"
 	startServer(t)
-	runSDKTestCommand(t, fileName, true)
+	runSDKTestCommand(t, fileName)
 	// Verify table columns include history mode columns
 	assertTableColumns(t, tableName, [][]string{
 		{"id", "Int32", ""},
@@ -371,12 +371,11 @@ func TestHistoryMode(t *testing.T) {
 		{"5", "name 5", "TODO", "2025-11-10 20:57:00.000000000", "2262-04-11 23:47:16.000000000", "true"}}, dbRecordsCSVStr)
 }
 
-
 func TestSchemaMigrationsDDL(t *testing.T) {
 	fileName := "schema_migrations_input_ddl.json"
 	tableName := "transaction"
 	startServer(t)
-	runSDKTestCommand(t, fileName, true)
+	runSDKTestCommand(t, fileName)
 	// After DDL migrations: add_column (operation_time UTC_DATETIME), change_column_data_type (amount DOUBLE->FLOAT), drop_column (desc)
 	assertTableColumns(t, tableName, [][]string{
 		{"id", "Int32", ""},
@@ -473,7 +472,7 @@ func generateAndWriteInputFile(t *testing.T, tableName string, n uint) [][]strin
 	deleteRows := make([]Row, n/50)
 	assertRows := make([][]string, n) // should exactly match ClickHouse CSV format output after input.json is processed
 	createdAt := time.Date(2021, 2, 15, 14, 13, 12, 0, time.UTC)
-	for i := uint(0); i < n; i++ {
+	for i := range n {
 		rowCreatedAt := createdAt.Add(time.Duration(i) * time.Second)
 		createdAtStr := rowCreatedAt.Format("2006-01-02T15:04:05")
 		data := fmt.Sprintf("original for %d", i)
@@ -600,7 +599,7 @@ func runQuery(t *testing.T, query string) string {
 	if !conf.Local {
 		cmdArgs = append(cmdArgs, "--secure")
 	}
-	command := exec.Command("docker", cmdArgs...)
+	command := exec.CommandContext(t.Context(), "docker", cmdArgs...)
 	out, err := command.Output()
 	var exitError *exec.ExitError
 	if errors.As(err, &exitError) {
@@ -613,7 +612,8 @@ func runQuery(t *testing.T, query string) string {
 
 func isPortReady(t *testing.T, port uint) (isOpen bool) {
 	address := net.JoinHostPort("localhost", fmt.Sprintf("%d", port))
-	conn, _ := net.DialTimeout("tcp", address, dialTimeout)
+	dialer := net.Dialer{Timeout: dialTimeout}
+	conn, _ := dialer.DialContext(t.Context(), "tcp", address)
 	if conn != nil {
 		err := conn.Close()
 		require.NoError(t, err)
@@ -635,14 +635,12 @@ func waitPortIsReady(t *testing.T, port uint) {
 	t.Fatalf("Port is not ready after %d retries", maxDialRetries)
 }
 
-func runSDKTestCommand(t *testing.T, inputFileName string, recreateDatabase bool) {
-	if recreateDatabase {
-		runQuery(t, "DROP DATABASE IF EXISTS tester SYNC")
-		runQuery(t, "CREATE DATABASE IF NOT EXISTS tester")
-	}
+func runSDKTestCommand(t *testing.T, inputFileName string) {
+	runQuery(t, "DROP DATABASE IF EXISTS tester SYNC")
+	runQuery(t, "CREATE DATABASE IF NOT EXISTS tester")
 	projectRootDir := getProjectRootDir(t)
 
-	command := exec.Command("make", "sdk-test")
+	command := exec.CommandContext(t.Context(), "make", "sdk-test")
 	command.Dir = projectRootDir
 	command.Env = os.Environ()
 	command.Env = append(command.Env, fmt.Sprintf("TEST_ARGS=--input-file=%s", inputFileName))

--- a/internal/scripts/mutation_batch_size_test.go
+++ b/internal/scripts/mutation_batch_size_test.go
@@ -104,10 +104,8 @@ func runBatchSizeTest(t *testing.T, cfg batchSizeTestConfig) {
 			},
 		},
 		{
-			name: "DELETE",
-			generate: func(csv [][]string, cols *types.CSVColumns, table sql.QualifiedTableName) (string, error) {
-				return sql.GetHardDeleteStatement(csv, cols, table)
-			},
+			name:     "DELETE",
+			generate: sql.GetHardDeleteStatement,
 		},
 		{
 			name: "DELETE+Timestamp",
@@ -186,7 +184,7 @@ func runMutationSweep(
 
 func generateSimpleCSV(rowCount uint) [][]string {
 	csv := make([][]string, rowCount)
-	for i := uint(0); i < rowCount; i++ {
+	for i := range rowCount {
 		csv[i] = []string{
 			fmt.Sprintf("%d", i),
 			fmt.Sprintf("name_%d", i),
@@ -220,7 +218,7 @@ func makeSimpleCSVColumns() *types.CSVColumns {
 
 func generateRealisticCSV(rowCount uint) [][]string {
 	csv := make([][]string, rowCount)
-	for i := uint(0); i < rowCount; i++ {
+	for i := range rowCount {
 		csv[i] = []string{
 			fmt.Sprintf("%d", 160112174822+i),
 			fmt.Sprintf("%d", 361397856850+i),


### PR DESCRIPTION
Found out there're more linters that we can activate that do nice things, like raising errors when we redeclare already predeclared built-in functions https://golangci-lint.run/docs/linters/configuration/#predeclared 

Added that and a bunch of more linters more. We can activate a few more but that would require a bit of more work, we can do it in batches