### PR TITLE
Retry session expired errors

### DIFF
--- a/destination/common/retry/retry.go
+++ b/destination/common/retry/retry.go
@@ -11,10 +11,18 @@ import (
 	"fivetran.com/fivetran_sdk/destination/common/benchmark"
 	"fivetran.com/fivetran_sdk/destination/common/flags"
 	"fivetran.com/fivetran_sdk/destination/common/log"
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
-// OnNetError retries the given operation only if it returns a net.Error using exponential backoff strategy.
-// Any other error will be returned immediately.
+// chCodeKeeperException is the ClickHouse server error code KEEPER_EXCEPTION.
+// It surfaces transient ZooKeeper/Keeper failures such as "Session expired",
+// connection loss, and operation timeouts — all worth retrying.
+// Reference: https://github.com/ClickHouse/ClickHouse/blob/master/src/Common/ErrorCodes.cpp
+const chCodeKeeperException = 999
+
+// OnNetError retries the given operation if it returns a transient error
+// (network failure or a ClickHouse Keeper exception) using an exponential
+// backoff strategy. Any other error will be returned immediately.
 // Execution time of all operations is measured and logged as notice.
 func OnNetError(
 	op func() error,
@@ -33,7 +41,7 @@ func OnNetError(
 		if err == nil {
 			return nil
 		}
-		if !IsNetError(err) {
+		if !IsRetryable(err) {
 			return err
 		}
 		failCount++
@@ -56,8 +64,9 @@ func OnNetError(
 	return nil
 }
 
-// OnNetErrorWithData retries the given operation only if it returns a net.Error using exponential backoff strategy.
-// Any other error will be returned immediately.
+// OnNetErrorWithData retries the given operation if it returns a transient
+// error (network failure or a ClickHouse Keeper exception) using an
+// exponential backoff strategy. Any other error will be returned immediately.
 // Execution time of all operations is measured and logged as notice.
 func OnNetErrorWithData[T any](
 	op func() (T, error),
@@ -76,7 +85,7 @@ func OnNetErrorWithData[T any](
 		if err == nil {
 			return data, nil
 		}
-		if !IsNetError(err) {
+		if !IsRetryable(err) {
 			var empty T
 			return empty, err
 		}
@@ -145,6 +154,24 @@ func IsNetError(err error) bool {
 	}
 	var netErr net.Error
 	return errors.As(err, &netErr) || errors.Is(err, io.EOF)
+}
+
+// IsKeeperException returns true if err is (or wraps) a ClickHouse server
+// exception with code 999 (KEEPER_EXCEPTION). These are transient failures of
+// the underlying ZooKeeper/Keeper layer — most commonly "Session expired",
+// connection loss, or operation timeout — and should be retried.
+func IsKeeperException(err error) bool {
+	if err == nil {
+		return false
+	}
+	var ex *clickhouse.Exception
+	return errors.As(err, &ex) && ex.Code == chCodeKeeperException
+}
+
+// IsRetryable returns true if err represents a transient failure that the
+// retry loops should back off on and retry
+func IsRetryable(err error) bool {
+	return IsNetError(err) || IsKeeperException(err)
 }
 
 func GetDelayConfig() (initial time.Duration, max time.Duration) {

--- a/destination/common/retry/retry_test.go
+++ b/destination/common/retry/retry_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"fivetran.com/fivetran_sdk/destination/common/flags"
+	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -39,6 +40,32 @@ func TestIsNetError(t *testing.T) {
 	assert.True(t, IsNetError(syscall.ECONNRESET))
 	assert.True(t, IsNetError(fmt.Errorf("send data: connection broken (EPIPE) to 1.2.3.4: %w", syscall.EPIPE)))
 	assert.True(t, IsNetError(net.ErrClosed))
+
+	// ClickHouse Keeper exceptions are NOT net errors — they are server-side
+	// exceptions handled by IsKeeperException / IsRetryable.
+	assert.False(t, IsNetError(&clickhouse.Exception{Code: 999, Message: "Session expired"}))
+}
+
+func TestIsKeeperException(t *testing.T) {
+	assert.False(t, IsKeeperException(nil))
+	assert.False(t, IsKeeperException(errors.New("plain error")))
+	assert.False(t, IsKeeperException(io.EOF))
+
+	// Code 999 (KEEPER_EXCEPTION)
+	assert.True(t, IsKeeperException(&clickhouse.Exception{Code: 999, Message: "Session expired"}))
+
+	// Wrapped, as it would arrive from ExecStatement / benchmark layers.
+	wrapped := fmt.Errorf("ExecStatement(ALTER TABLE x) failed: %w",
+		&clickhouse.Exception{Code: 999, Message: "Session expired"})
+	assert.True(t, IsKeeperException(wrapped))
+
+	// Other ClickHouse codes must not match.
+	assert.False(t, IsKeeperException(&clickhouse.Exception{Code: 516, Message: "Authentication failed"}))
+}
+
+func TestIsRetryable(t *testing.T) {
+	assert.True(t, IsRetryable(makeNetError()))
+	assert.True(t, IsRetryable(&clickhouse.Exception{Code: 999, Message: "Session expired"}))
 }
 
 func TestGetBackoffDelay(t *testing.T) {
@@ -108,6 +135,34 @@ func TestRetryNetError(t *testing.T) {
 		return makeNetError()
 	}, context.Background(), "TestRetryNetError", false)
 	assert.ErrorContains(t, err, "TestRetryNetError failed after 2 attempts")
+}
+
+func TestRetryKeeperException(t *testing.T) {
+	defer setupSuite()(t)
+
+	// A code 999 / "Session expired" eventually succeeds after one retry.
+	count := 0
+	err := OnNetError(func() error {
+		count++
+		if count == 2 {
+			return nil
+		}
+		return &clickhouse.Exception{Code: 999, Message: "Session expired"}
+	}, context.Background(), "TestRetryKeeperException", false)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, count)
+
+	// Non-retryable ClickHouse exceptions surface immediately.
+	count = 0
+	err = OnNetError(func() error {
+		count++
+		return &clickhouse.Exception{Code: 497, Message: "Not enough privileges"}
+	}, context.Background(), "TestRetryKeeperException", false)
+	assert.Error(t, err)
+	assert.Equal(t, 1, count)
+	var ex *clickhouse.Exception
+	assert.True(t, errors.As(err, &ex))
+	assert.EqualValues(t, 497, ex.Code)
 }
 
 func TestRetryNetErrorWithData(t *testing.T) {

--- a/destination/db/clickhouse.go
+++ b/destination/db/clickhouse.go
@@ -504,14 +504,6 @@ func (conn *ClickHouseConnection) RenameTable(
 	if !isTableAlreadyExistsErr(err) {
 		return err
 	}
-	destExists, checkErr := conn.CheckTableExists(ctx, schemaName, toTableName)
-	if checkErr != nil {
-		return fmt.Errorf("error checking if destination table %s.%s exists after rename failure: %w; initial cause: %w",
-			schemaName, toTableName, checkErr, err)
-	}
-	if !destExists {
-		return err
-	}
 	sourceExists, checkErr := conn.CheckTableExists(ctx, schemaName, fromTableName)
 	if checkErr != nil {
 		return fmt.Errorf("error checking if source table %s.%s exists after rename failure: %w; initial cause: %w",

--- a/destination/db/clickhouse.go
+++ b/destination/db/clickhouse.go
@@ -324,19 +324,43 @@ func (conn *ClickHouseConnection) CheckDatabaseExists(
 	if err != nil {
 		return false, err
 	}
-	rows, err := conn.ExecQuery(ctx, statement, checkDatabaseExists, false)
+	return conn.scanExistsResult(ctx, statement, checkDatabaseExists)
+}
+
+// CheckTableExists returns true if the table exists in the given schema.
+func (conn *ClickHouseConnection) CheckTableExists(
+	ctx context.Context,
+	schemaName string,
+	tableName string,
+) (bool, error) {
+	statement, err := sql.GetCheckTableExistsStatement(schemaName, tableName)
+	if err != nil {
+		return false, err
+	}
+	return conn.scanExistsResult(ctx, statement, checkTableExists)
+}
+
+// scanExistsResult runs an `EXISTS …` statement and returns whether the
+// object was reported to exist. ClickHouse returns a single UInt8 column
+// (1 if present, 0 otherwise) for these statements.
+func (conn *ClickHouseConnection) scanExistsResult(
+	ctx context.Context,
+	statement string,
+	op connectionOpType,
+) (bool, error) {
+	rows, err := conn.ExecQuery(ctx, statement, op, false)
 	if err != nil {
 		return false, err
 	}
 	defer rows.Close() //nolint:errcheck
-	var count uint64
 	if !rows.Next() {
 		return false, fmt.Errorf("unexpected empty result from %s", statement)
 	}
-	if err = rows.Scan(&count); err != nil {
+	var result uint8
+	if err = rows.Scan(&result); err != nil {
 		return false, err
 	}
-	return count > 0, nil
+	return result == 1, nil
 }
 
 func (conn *ClickHouseConnection) CreateDatabase(
@@ -467,9 +491,38 @@ func (conn *ClickHouseConnection) RenameTable(
 		return err
 	}
 	err = conn.ExecStatement(ctx, renameStmt, alterTablePKRename, false)
-	if err != nil {
+	if err == nil {
+		return nil
+	}
+
+	// this method makes the operation safe to retry by recovering from the specific case where
+	// a previous attempt completed at the server but the response was lost on the
+	// wire. After a successful first attempt the source table is gone and the
+	// destination table exists; the retry then fails with code 57
+	// (TABLE_ALREADY_EXISTS) because ClickHouse checks the destination collision
+	// before resolving the missing source.
+	if !isTableAlreadyExistsErr(err) {
 		return err
 	}
+	destExists, checkErr := conn.CheckTableExists(ctx, schemaName, toTableName)
+	if checkErr != nil {
+		return fmt.Errorf("error checking if destination table %s.%s exists after rename failure: %w; initial cause: %w",
+			schemaName, toTableName, checkErr, err)
+	}
+	if !destExists {
+		return err
+	}
+	sourceExists, checkErr := conn.CheckTableExists(ctx, schemaName, fromTableName)
+	if checkErr != nil {
+		return fmt.Errorf("error checking if source table %s.%s exists after rename failure: %w; initial cause: %w",
+			schemaName, fromTableName, checkErr, err)
+	}
+	if sourceExists {
+		return err
+	}
+	log.Info(fmt.Sprintf(
+		"RenameTable: source %s.%s is gone and destination %s.%s exists; treating rename as already applied",
+		schemaName, fromTableName, schemaName, toTableName))
 	return nil
 }
 
@@ -1147,11 +1200,23 @@ func isDatabaseBeingCreatedErr(err error) bool {
 	return true
 }
 
+// isTableAlreadyExistsErr reports whether err is (or wraps) a ClickHouse
+// server exception with code 57 (TABLE_ALREADY_EXISTS).
+func isTableAlreadyExistsErr(err error) bool {
+	var exception *clickhouse.Exception
+	ok := errors.As(err, &exception)
+	if !ok || exception.Code != 57 {
+		return false
+	}
+	return true
+}
+
 type connectionOpType string
 
 const (
 	createDatabase             connectionOpType = "CreateDatabase"
 	checkDatabaseExists        connectionOpType = "CheckDatabaseExists"
+	checkTableExists           connectionOpType = "CheckTableExists"
 	createTable                connectionOpType = "CreateTable"
 	describeTable              connectionOpType = "DescribeTable"
 	alterTable                 connectionOpType = "AlterTable"

--- a/destination/db/clickhouse_integration_test.go
+++ b/destination/db/clickhouse_integration_test.go
@@ -154,6 +154,130 @@ func TestGrants(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestRenameTable(t *testing.T) {
+	ctx := context.Background()
+	conn := getTestConnection(t, ctx, map[string]string{
+		"host":     "localhost",
+		"port":     "9000",
+		"username": "default",
+		"local":    "true",
+	})
+	defer conn.Close() //nolint:errcheck
+
+	dbName := "fivetran_test"
+	err := conn.Exec(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", dbName))
+	require.NoError(t, err)
+
+	suffix := strings.ReplaceAll(uuid.New().String(), "-", "_")
+	sourceTable := fmt.Sprintf("test_rename_happy_src_%s", suffix)
+	destTable := fmt.Sprintf("test_rename_happy_dst_%s", suffix)
+
+	err = conn.Exec(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s.%s", dbName, sourceTable))
+	require.NoError(t, err)
+	err = conn.Exec(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s.%s", dbName, destTable))
+	require.NoError(t, err)
+	err = conn.Exec(ctx, fmt.Sprintf(
+		"CREATE TABLE %s.%s (id Int64) ENGINE = MergeTree ORDER BY id", dbName, sourceTable))
+	require.NoError(t, err)
+	defer func() {
+		// Whichever name the table currently has after the test, drop it.
+		err := conn.Exec(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s.%s", dbName, sourceTable))
+		assert.NoError(t, err)
+		err = conn.Exec(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s.%s", dbName, destTable))
+		assert.NoError(t, err)
+	}()
+
+	// Pre-condition: source exists, destination does not.
+	sourceExists, err := conn.CheckTableExists(ctx, dbName, sourceTable)
+	require.NoError(t, err)
+	require.True(t, sourceExists)
+	destExists, err := conn.CheckTableExists(ctx, dbName, destTable)
+	require.NoError(t, err)
+	require.False(t, destExists)
+
+	err = conn.RenameTable(ctx, dbName, sourceTable, destTable)
+	require.NoError(t, err)
+
+	// Post-condition: source is gone, destination exists.
+	sourceExists, err = conn.CheckTableExists(ctx, dbName, sourceTable)
+	require.NoError(t, err)
+	assert.False(t, sourceExists)
+	destExists, err = conn.CheckTableExists(ctx, dbName, destTable)
+	require.NoError(t, err)
+	assert.True(t, destExists)
+}
+
+func TestRenameTableIdempotentOnRetry(t *testing.T) {
+	ctx := context.Background()
+	conn := getTestConnection(t, ctx, map[string]string{
+		"host":     "localhost",
+		"port":     "9000",
+		"username": "default",
+		"local":    "true",
+	})
+	defer conn.Close() //nolint:errcheck
+
+	dbName := "fivetran_test"
+	err := conn.Exec(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", dbName))
+	require.NoError(t, err)
+
+	createTable := func(t *testing.T, table string) {
+		t.Helper()
+		err := conn.Exec(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s.%s", dbName, table))
+		require.NoError(t, err)
+		err = conn.Exec(ctx, fmt.Sprintf(
+			"CREATE TABLE %s.%s (id Int64) ENGINE = MergeTree ORDER BY id", dbName, table))
+		require.NoError(t, err)
+	}
+	dropTable := func(t *testing.T, table string) {
+		t.Helper()
+		err := conn.Exec(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s.%s", dbName, table))
+		assert.NoError(t, err)
+	}
+
+	t.Run("rename_already_applied_is_a_no_op", func(t *testing.T) {
+		// Simulate the post-success retry state: the rename has already been
+		// applied, so only the destination table exists. RenameTable should
+		// recognize this and not return an error.
+		suffix := strings.ReplaceAll(uuid.New().String(), "-", "_")
+		sourceTable := fmt.Sprintf("test_rename_src_%s", suffix)
+		destTable := fmt.Sprintf("test_rename_dst_%s", suffix)
+		createTable(t, destTable)
+		defer dropTable(t, destTable)
+
+		err := conn.RenameTable(ctx, dbName, sourceTable, destTable)
+		require.NoError(t, err)
+	})
+
+	t.Run("missing_source_and_destination_returns_error", func(t *testing.T) {
+		// When neither side exists, RenameTable must still surface the
+		// underlying error (it would mask a real bug otherwise).
+		suffix := strings.ReplaceAll(uuid.New().String(), "-", "_")
+		missingSource := fmt.Sprintf("test_rename_missing_src_%s", suffix)
+		missingDest := fmt.Sprintf("test_rename_missing_dst_%s", suffix)
+
+		err := conn.RenameTable(ctx, dbName, missingSource, missingDest)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "code: 60")
+	})
+
+	t.Run("source_and_destination_both_exist_returns_error", func(t *testing.T) {
+		// A real conflict (someone created the destination independently
+		// while the source still exists) must not be silently swallowed.
+		suffix := strings.ReplaceAll(uuid.New().String(), "-", "_")
+		sourceTable := fmt.Sprintf("test_rename_conflict_src_%s", suffix)
+		destTable := fmt.Sprintf("test_rename_conflict_dst_%s", suffix)
+		createTable(t, sourceTable)
+		createTable(t, destTable)
+		defer dropTable(t, sourceTable)
+		defer dropTable(t, destTable)
+
+		err := conn.RenameTable(ctx, dbName, sourceTable, destTable)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "code: 57")
+	})
+}
+
 func TestDescribeTable(t *testing.T) {
 	conn := getTestConnection(t, context.Background(), map[string]string{
 		"host":     "localhost",

--- a/destination/db/sql/sql.go
+++ b/destination/db/sql/sql.go
@@ -27,9 +27,9 @@ func GetQualifiedTableName(schemaName string, tableName string) (QualifiedTableN
 // GetAlterTableStatement sample generated query:
 //
 //	ALTER TABLE `foo`.`bar`
-//	ADD COLUMN `c1` String COMMENT 'foobar',
-//	DROP COLUMN `c2`,
-//	MODIFY COLUMN `c3` Int32 COMMENT ''
+//	ADD COLUMN IF NOT EXISTS `c1` String COMMENT 'foobar',
+//	DROP COLUMN IF EXISTS `c2`,
+//	MODIFY COLUMN IF EXISTS `c3` Int32 COMMENT ''
 //
 // Comments are added to distinguish certain Fivetran data types, see data_types.FivetranToClickHouseTypeWithComment.
 func GetAlterTableStatement(schemaName string, tableName string, ops []*types.AlterTableOp) (string, error) {
@@ -49,7 +49,7 @@ func GetAlterTableStatement(schemaName string, tableName string, ops []*types.Al
 			if op.Type == nil {
 				return "", fmt.Errorf("type for column %s is not specified", op.Column)
 			}
-			statementsBuilder.WriteString(fmt.Sprintf("ADD COLUMN %s %s", identifier(op.Column), *op.Type))
+			statementsBuilder.WriteString(fmt.Sprintf("ADD COLUMN IF NOT EXISTS %s %s", identifier(op.Column), *op.Type))
 			if op.Comment != nil {
 				statementsBuilder.WriteString(fmt.Sprintf(" COMMENT '%s'", *op.Comment))
 			}
@@ -57,12 +57,12 @@ func GetAlterTableStatement(schemaName string, tableName string, ops []*types.Al
 			if op.Type == nil {
 				return "", fmt.Errorf("type for column %s is not specified", op.Column)
 			}
-			statementsBuilder.WriteString(fmt.Sprintf("MODIFY COLUMN %s %s", identifier(op.Column), *op.Type))
+			statementsBuilder.WriteString(fmt.Sprintf("MODIFY COLUMN IF EXISTS %s %s", identifier(op.Column), *op.Type))
 			if op.Comment != nil {
 				statementsBuilder.WriteString(fmt.Sprintf(" COMMENT '%s'", *op.Comment))
 			}
 		case types.AlterTableDrop:
-			statementsBuilder.WriteString(fmt.Sprintf("DROP COLUMN %s", identifier(op.Column)))
+			statementsBuilder.WriteString(fmt.Sprintf("DROP COLUMN IF EXISTS %s", identifier(op.Column)))
 		}
 		if count < len(ops)-1 {
 			statementsBuilder.WriteString(",")
@@ -79,7 +79,15 @@ func GetCheckDatabaseExistsStatement(schemaName string) (string, error) {
 	if schemaName == "" {
 		return "", fmt.Errorf("schema name is empty")
 	}
-	return fmt.Sprintf("SELECT COUNT(*) FROM system.databases WHERE `name` = '%s'", schemaName), nil
+	return fmt.Sprintf("EXISTS DATABASE %s", identifier(schemaName)), nil
+}
+
+func GetCheckTableExistsStatement(schemaName string, tableName string) (string, error) {
+	fullName, err := GetQualifiedTableName(schemaName, tableName)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("EXISTS TABLE %s", fullName), nil
 }
 
 func GetCreateDatabaseStatement(schemaName string) (string, error) {
@@ -105,7 +113,7 @@ func GetSelectFromSystemGrantsQuery(username string) (string, error) {
 
 // GetCreateTableStatement sample generated query:
 //
-//	CREATE TABLE `foo`.`bar`
+//	CREATE TABLE IF NOT EXISTS `foo`.`bar`
 //	(`id` Int64, `c2` Nullable(String), `_fivetran_synced` DateTime64(9, 'UTC'), `_fivetran_deleted` Bool)
 //	ENGINE = ReplacingMergeTree(`_fivetran_synced`)
 //	ORDER BY (`id`)
@@ -146,7 +154,7 @@ func GetCreateTableStatement(
 	columns := columnsBuilder.String()
 
 	query := fmt.Sprintf(
-		"CREATE TABLE %s (%s) ENGINE = ReplacingMergeTree(%s) ORDER BY (%s)",
+		"CREATE TABLE IF NOT EXISTS %s (%s) ENGINE = ReplacingMergeTree(%s) ORDER BY (%s)",
 		fullName, columns, identifier(constants.FivetranSynced), strings.Join(orderByCols, ","))
 	return query, nil
 }

--- a/destination/db/sql/sql_test.go
+++ b/destination/db/sql/sql_test.go
@@ -30,50 +30,50 @@ func TestGetAlterTableStatement(t *testing.T) {
 		{Op: types.AlterTableAdd, Column: "qaz", Type: &intType},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, "ALTER TABLE `foo`.`bar` ADD COLUMN `qaz` Int32", statement)
+	assert.Equal(t, "ALTER TABLE `foo`.`bar` ADD COLUMN IF NOT EXISTS `qaz` Int32", statement)
 
 	statement, err = GetAlterTableStatement("foo", "bar", []*types.AlterTableOp{
 		{Op: types.AlterTableAdd, Column: "qaz", Type: &intType, Comment: &emptyComment},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, "ALTER TABLE `foo`.`bar` ADD COLUMN `qaz` Int32 COMMENT ''", statement)
+	assert.Equal(t, "ALTER TABLE `foo`.`bar` ADD COLUMN IF NOT EXISTS `qaz` Int32 COMMENT ''", statement)
 
 	statement, err = GetAlterTableStatement("foo", "bar", []*types.AlterTableOp{
 		{Op: types.AlterTableAdd, Column: "qaz", Type: &intType, Comment: &comment},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, "ALTER TABLE `foo`.`bar` ADD COLUMN `qaz` Int32 COMMENT 'foobar'", statement)
+	assert.Equal(t, "ALTER TABLE `foo`.`bar` ADD COLUMN IF NOT EXISTS `qaz` Int32 COMMENT 'foobar'", statement)
 
 	statement, err = GetAlterTableStatement("foo", "bar", []*types.AlterTableOp{
 		{Op: types.AlterTableDrop, Column: "qaz"},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, "ALTER TABLE `foo`.`bar` DROP COLUMN `qaz`", statement)
+	assert.Equal(t, "ALTER TABLE `foo`.`bar` DROP COLUMN IF EXISTS `qaz`", statement)
 
 	// Type and Comment are ignored with AlterTableDrop
 	statement, err = GetAlterTableStatement("foo", "bar", []*types.AlterTableOp{
 		{Op: types.AlterTableDrop, Column: "qaz", Type: &strType, Comment: &comment},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, "ALTER TABLE `foo`.`bar` DROP COLUMN `qaz`", statement)
+	assert.Equal(t, "ALTER TABLE `foo`.`bar` DROP COLUMN IF EXISTS `qaz`", statement)
 
 	statement, err = GetAlterTableStatement("foo", "bar", []*types.AlterTableOp{
 		{Op: types.AlterTableModify, Column: "qaz", Type: &strType},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, "ALTER TABLE `foo`.`bar` MODIFY COLUMN `qaz` String", statement)
+	assert.Equal(t, "ALTER TABLE `foo`.`bar` MODIFY COLUMN IF EXISTS `qaz` String", statement)
 
 	statement, err = GetAlterTableStatement("foo", "bar", []*types.AlterTableOp{
 		{Op: types.AlterTableModify, Column: "qaz", Type: &strType, Comment: &emptyComment},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, "ALTER TABLE `foo`.`bar` MODIFY COLUMN `qaz` String COMMENT ''", statement)
+	assert.Equal(t, "ALTER TABLE `foo`.`bar` MODIFY COLUMN IF EXISTS `qaz` String COMMENT ''", statement)
 
 	statement, err = GetAlterTableStatement("foo", "bar", []*types.AlterTableOp{
 		{Op: types.AlterTableModify, Column: "qaz", Type: &strType, Comment: &comment},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, "ALTER TABLE `foo`.`bar` MODIFY COLUMN `qaz` String COMMENT 'foobar'", statement)
+	assert.Equal(t, "ALTER TABLE `foo`.`bar` MODIFY COLUMN IF EXISTS `qaz` String COMMENT 'foobar'", statement)
 
 	statement, err = GetAlterTableStatement("foo", "bar", []*types.AlterTableOp{
 		{Op: types.AlterTableAdd, Column: "qaz", Type: &strType, Comment: &comment},
@@ -83,7 +83,7 @@ func TestGetAlterTableStatement(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Equal(t,
-		"ALTER TABLE `foo`.`bar` ADD COLUMN `qaz` String COMMENT 'foobar',DROP COLUMN `qux`,MODIFY COLUMN `zaq` Int32 COMMENT '',MODIFY COLUMN `qwe` String",
+		"ALTER TABLE `foo`.`bar` ADD COLUMN IF NOT EXISTS `qaz` String COMMENT 'foobar',DROP COLUMN IF EXISTS `qux`,MODIFY COLUMN IF EXISTS `zaq` Int32 COMMENT '',MODIFY COLUMN IF EXISTS `qwe` String",
 		statement)
 
 	_, err = GetAlterTableStatement("foo", "bar", []*types.AlterTableOp{})
@@ -111,7 +111,7 @@ func TestGetCreateTableStatement(t *testing.T) {
 			{Name: "_fivetran_deleted", Type: "Boolean"},
 		}))
 	assert.NoError(t, err)
-	assert.Equal(t, "CREATE TABLE `foo`.`bar` (`qaz` Int32,`qux` String,`_fivetran_synced` DateTime64(9, 'UTC'),`_fivetran_deleted` Boolean) ENGINE = ReplacingMergeTree(`_fivetran_synced`) ORDER BY (`qux`)", statement)
+	assert.Equal(t, "CREATE TABLE IF NOT EXISTS `foo`.`bar` (`qaz` Int32,`qux` String,`_fivetran_synced` DateTime64(9, 'UTC'),`_fivetran_deleted` Boolean) ENGINE = ReplacingMergeTree(`_fivetran_synced`) ORDER BY (`qux`)", statement)
 
 	statement, err = GetCreateTableStatement("foo", "bar",
 		types.MakeTableDescription([]*types.ColumnDefinition{
@@ -121,7 +121,7 @@ func TestGetCreateTableStatement(t *testing.T) {
 			{Name: "_fivetran_deleted", Type: "Boolean"},
 		}))
 	assert.NoError(t, err)
-	assert.Equal(t, "CREATE TABLE `foo`.`bar` (`qaz` Int32,`qux` String,`_fivetran_synced` DateTime64(9, 'UTC'),`_fivetran_deleted` Boolean) ENGINE = ReplacingMergeTree(`_fivetran_synced`) ORDER BY (`qaz`,`qux`)", statement)
+	assert.Equal(t, "CREATE TABLE IF NOT EXISTS `foo`.`bar` (`qaz` Int32,`qux` String,`_fivetran_synced` DateTime64(9, 'UTC'),`_fivetran_deleted` Boolean) ENGINE = ReplacingMergeTree(`_fivetran_synced`) ORDER BY (`qaz`,`qux`)", statement)
 
 	statement, err = GetCreateTableStatement("foo", "bar",
 		types.MakeTableDescription([]*types.ColumnDefinition{
@@ -132,7 +132,7 @@ func TestGetCreateTableStatement(t *testing.T) {
 			{Name: "_fivetran_deleted", Type: "Boolean"},
 		}))
 	assert.NoError(t, err)
-	assert.Equal(t, "CREATE TABLE `foo`.`bar` (`i` Int32,`x` String COMMENT 'XML',`bin` String COMMENT 'BINARY',`_fivetran_synced` DateTime64(9, 'UTC'),`_fivetran_deleted` Boolean) ENGINE = ReplacingMergeTree(`_fivetran_synced`) ORDER BY (`i`)", statement)
+	assert.Equal(t, "CREATE TABLE IF NOT EXISTS `foo`.`bar` (`i` Int32,`x` String COMMENT 'XML',`bin` String COMMENT 'BINARY',`_fivetran_synced` DateTime64(9, 'UTC'),`_fivetran_deleted` Boolean) ENGINE = ReplacingMergeTree(`_fivetran_synced`) ORDER BY (`i`)", statement)
 
 	// works without _fivetran_deleted column
 	statement, err = GetCreateTableStatement("foo", "bar",
@@ -142,7 +142,7 @@ func TestGetCreateTableStatement(t *testing.T) {
 			{Name: "_fivetran_synced", Type: "DateTime64(9, 'UTC')"},
 		}))
 	assert.NoError(t, err)
-	assert.Equal(t, "CREATE TABLE `foo`.`bar` (`i` Int32,`x` String,`_fivetran_synced` DateTime64(9, 'UTC')) ENGINE = ReplacingMergeTree(`_fivetran_synced`) ORDER BY (`i`)", statement)
+	assert.Equal(t, "CREATE TABLE IF NOT EXISTS `foo`.`bar` (`i` Int32,`x` String,`_fivetran_synced` DateTime64(9, 'UTC')) ENGINE = ReplacingMergeTree(`_fivetran_synced`) ORDER BY (`i`)", statement)
 
 	_, err = GetCreateTableStatement("foo", "", nil)
 	assert.ErrorContains(t, err, "table name is empty")
@@ -305,10 +305,22 @@ func TestGetSelectByPrimaryKeysQuery(t *testing.T) {
 func TestGetCheckDatabaseExistsStatement(t *testing.T) {
 	statement, err := GetCheckDatabaseExistsStatement("foo")
 	assert.NoError(t, err)
-	assert.Equal(t, "SELECT COUNT(*) FROM system.databases WHERE `name` = 'foo'", statement)
+	assert.Equal(t, "EXISTS DATABASE `foo`", statement)
 
 	_, err = GetCheckDatabaseExistsStatement("")
 	assert.ErrorContains(t, err, "schema name is empty")
+}
+
+func TestGetCheckTableExistsStatement(t *testing.T) {
+	statement, err := GetCheckTableExistsStatement("foo", "bar")
+	assert.NoError(t, err)
+	assert.Equal(t, "EXISTS TABLE `foo`.`bar`", statement)
+
+	_, err = GetCheckTableExistsStatement("", "bar")
+	assert.ErrorContains(t, err, "schema name for table bar is empty")
+
+	_, err = GetCheckTableExistsStatement("foo", "")
+	assert.ErrorContains(t, err, "table name is empty")
 }
 
 func TestGetCreateDatabaseStatement(t *testing.T) {

--- a/destination/main_e2e_test.go
+++ b/destination/main_e2e_test.go
@@ -668,7 +668,8 @@ func TestUserFriendlyConnectionFailureMessage(t *testing.T) {
 	// allocates a free ephemeral port, capture it, then close the listener.
 	// More reliable than hard-coding a port (which may be in use on some
 	// dev/CI machines) and produces a deterministic "connection refused".
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	var lc net.ListenConfig
+	listener, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	unusedPort := listener.Addr().(*net.TCPAddr).Port
 	require.NoError(t, listener.Close())


### PR DESCRIPTION
The error `code: 999, message: Session expired` may happen when the connection between ClickHouse and Keeper services is interrupted. This may happen for things like a network hiccup or a Keeper restart. This error should only happen in unfrequent situations, but we still need to deal with it.

That error is sent in the middle of a communication between the CH service and the Keeper instance it's connected. That communication is usually done to do ops like creating a mutation operation. As that's the case, an error in the connection may happen before the mutation is created, or right after.

A retry should be done from the client to manage this situation. If the client needs to do several things, it may need to take into account that some operations will need to be checked before getting retried. In our case it's safe to just retry the sql as we don't do operations that depends on having a shared state stored in Keeper between them. That means that:
- `SELECT` can be safely retried
- `INSERT INTO ... SELECT` can be retried as we have all the deduplication mechanism to handle that
- Table schema operations (`ADD COLUMN`, `DROP COLUMN`, `CREATE TABLE`, `CREATE DATABASE`...) can now be safely retried after the adding `IF [NOT] EXISTS` modifiers.
- `RENAME` operation now manages the situation where a retry may fail because the operation was already applied