### PR TITLE
Improve error messages by including an user friendly texts

### DIFF
--- a/destination/main_e2e_test.go
+++ b/destination/main_e2e_test.go
@@ -701,6 +701,6 @@ func TestUserFriendlyConnectionFailureMessage(t *testing.T) {
 		"missing technical details section; got: %q", msg)
 	assert.Contains(t, msg, "ClickHouse connection error",
 		"missing original sentinel string; got: %q", msg)
-	assert.Contains(t, msg, "ping failed after 1 attempts",
+	assert.Contains(t, msg, "ping failed after",
 		"missing retry context from technical details; got: %q", msg)
 }

--- a/destination/main_e2e_test.go
+++ b/destination/main_e2e_test.go
@@ -665,6 +665,15 @@ func runSDKTestCommand(t *testing.T, inputFileName string, recreateDatabase bool
 // verifies that the resulting Task.Message contains both the friendly headline
 // and the underlying technical details
 func TestUserFriendlyConnectionFailureMessage(t *testing.T) {
+	// Discover a port we know nothing is listening on: bind to :0 so the kernel
+	// allocates a free ephemeral port, capture it, then close the listener.
+	// More reliable than hard-coding a port (which may be in use on some
+	// dev/CI machines) and produces a deterministic "connection refused".
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	unusedPort := listener.Addr().(*net.TCPAddr).Port
+	require.NoError(t, listener.Close())
+
 	prevMaxRetries := *flags.MaxRetries
 	prevDelay := *flags.InitialRetryDelayMilliseconds
 	*flags.MaxRetries = 1
@@ -677,8 +686,8 @@ func TestUserFriendlyConnectionFailureMessage(t *testing.T) {
 	s := &service.Server{}
 	resp, err := s.DescribeTable(context.Background(), &pb.DescribeTableRequest{
 		Configuration: map[string]string{
-			"host":     "localhost",
-			"port":     "9999",
+			"host":     "127.0.0.1",
+			"port":     fmt.Sprint(unusedPort),
 			"username": "default",
 			"local":    "true",
 		},

--- a/destination/main_e2e_test.go
+++ b/destination/main_e2e_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/csv"
 	"encoding/json"
 	"errors"
@@ -16,6 +17,9 @@ import (
 	"fivetran.com/fivetran_sdk/destination/cmd"
 	"fivetran.com/fivetran_sdk/destination/common/flags"
 	"fivetran.com/fivetran_sdk/destination/db/config"
+	"fivetran.com/fivetran_sdk/destination/service"
+	pb "fivetran.com/fivetran_sdk/proto"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -371,7 +375,6 @@ func TestHistoryMode(t *testing.T) {
 		{"5", "name 5", "TODO", "2025-11-10 20:57:00.000000000", "2262-04-11 23:47:16.000000000", "true"}}, dbRecordsCSVStr)
 }
 
-
 func TestSchemaMigrationsDDL(t *testing.T) {
 	fileName := "schema_migrations_input_ddl.json"
 	tableName := "transaction"
@@ -655,4 +658,49 @@ func runSDKTestCommand(t *testing.T, inputFileName string, recreateDatabase bool
 		t.Error(string(exitError.Stderr))
 	}
 	require.NoError(t, err)
+}
+
+// TestUserFriendlyConnectionFailureMessage drives the gRPC handler with a
+// destination configuration pointing at a non-existent ClickHouse instance and
+// verifies that the resulting Task.Message contains both the friendly headline
+// and the underlying technical details
+func TestUserFriendlyConnectionFailureMessage(t *testing.T) {
+	prevMaxRetries := *flags.MaxRetries
+	prevDelay := *flags.InitialRetryDelayMilliseconds
+	*flags.MaxRetries = 1
+	*flags.InitialRetryDelayMilliseconds = 1
+	defer func() {
+		*flags.MaxRetries = prevMaxRetries
+		*flags.InitialRetryDelayMilliseconds = prevDelay
+	}()
+
+	s := &service.Server{}
+	resp, err := s.DescribeTable(context.Background(), &pb.DescribeTableRequest{
+		Configuration: map[string]string{
+			"host":     "localhost",
+			"port":     "9999",
+			"username": "default",
+			"local":    "true",
+		},
+		SchemaName: "any_schema",
+		TableName:  "any_table",
+	})
+	require.NoError(t, err)
+
+	task := resp.GetTask()
+	require.NotNil(t, task, "expected DescribeTable to return a Task on connection failure, got: %+v", resp)
+
+	msg := task.GetMessage()
+	t.Logf("Task message: %s", msg)
+
+	assert.True(t, strings.HasPrefix(msg, "Failed to describe table `any_schema`.`any_table`: Could not reach the ClickHouse service."),
+		"missing operation/headline prefix; got: %q", msg)
+	assert.Contains(t, msg, "Verify the ClickHouse Cloud service is running and reachable",
+		"missing actionable hint; got: %q", msg)
+	assert.Contains(t, msg, "Technical details:",
+		"missing technical details section; got: %q", msg)
+	assert.Contains(t, msg, "ClickHouse connection error",
+		"missing original sentinel string; got: %q", msg)
+	assert.Contains(t, msg, "ping failed after 1 attempts",
+		"missing retry context from technical details; got: %q", msg)
 }

--- a/destination/service/responses.go
+++ b/destination/service/responses.go
@@ -176,14 +176,16 @@ const (
 
 // addUserReadableHintsToError produces the user-facing Task message that Fivetran will display:
 //
-//	"<operation>: <friendly message> Technical details: <err>."
+//	"<operation>: <friendly message> Technical details: <err>"
 func addUserReadableHintsToError(operation string, err error) string {
 	friendly := "Unexpected error in the ClickHouse destination. Please contact Fivetran support and include the technical details below."
 
 	var ex *clickhouse.Exception
 	switch {
-	case errors.Is(err, context.DeadlineExceeded), errors.Is(err, context.Canceled):
+	case errors.Is(err, context.DeadlineExceeded):
 		friendly = "The ClickHouse operation took too long to complete. Retry the sync. If the problem persists, check the performance of the SQL executed. You may need to optimize batch sizes or scale up the ClickHouse service."
+	case errors.Is(err, context.Canceled):
+		friendly = "The operation was cancelled before ClickHouse could complete it. Retry the sync."
 	case errors.As(err, &ex):
 		switch ex.Code {
 		case chCodeAuthenticationFailed, chCodeUnknownUser:
@@ -199,5 +201,5 @@ func addUserReadableHintsToError(operation string, err error) string {
 		friendly = "Could not reach the ClickHouse service. Verify the ClickHouse Cloud service is running and reachable from Fivetran (host, port, IP allowlist)."
 	}
 
-	return fmt.Sprintf("%s: %s Technical details: %s.", operation, friendly, err)
+	return fmt.Sprintf("%s: %s Technical details: %s", operation, friendly, err)
 }

--- a/destination/service/responses.go
+++ b/destination/service/responses.go
@@ -174,7 +174,7 @@ const (
 	chCodeAuthenticationFailed = 516
 )
 
-// addUserReadableHintsToError produces the user-facing Task message that Fivetran:
+// addUserReadableHintsToError produces the user-facing Task message that Fivetran will display:
 //
 //	"<operation>: <friendly message> Technical details: <err>."
 func addUserReadableHintsToError(operation string, err error) string {

--- a/destination/service/responses.go
+++ b/destination/service/responses.go
@@ -1,10 +1,14 @@
 package service
 
 import (
+	"context"
+	"errors"
 	"fmt"
 
+	"fivetran.com/fivetran_sdk/destination/common/retry"
 	"fivetran.com/fivetran_sdk/destination/db/config"
 	pb "fivetran.com/fivetran_sdk/proto"
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 var hostDescription = "ClickHouse Cloud service host without protocol or port. For example, my.service.clickhouse.cloud"
@@ -84,7 +88,7 @@ func GetConfigurationFormResponse() *pb.ConfigurationFormResponse {
 func FailedWriteBatchResponse(schemaName string, tableName string, err error) *pb.WriteBatchResponse {
 	return &pb.WriteBatchResponse{
 		Response: &pb.WriteBatchResponse_Task{
-			Task: toTask(fmt.Sprintf("Failed to write batch into `%s`.`%s`, cause: %s", schemaName, tableName, err)),
+			Task: toTask(addUserReadableHintsToError(fmt.Sprintf("Failed to write batch into `%s`.`%s`", schemaName, tableName), err)),
 		},
 	}
 }
@@ -92,7 +96,7 @@ func FailedWriteBatchResponse(schemaName string, tableName string, err error) *p
 func FailedWriteHistoryBatchResponse(schemaName string, tableName string, err error) *pb.WriteBatchResponse {
 	return &pb.WriteBatchResponse{
 		Response: &pb.WriteBatchResponse_Task{
-			Task: toTask(fmt.Sprintf("Failed to write history batch into `%s`.`%s`, cause: %s", schemaName, tableName, err)),
+			Task: toTask(addUserReadableHintsToError(fmt.Sprintf("Failed to write history batch into `%s`.`%s`", schemaName, tableName), err)),
 		},
 	}
 }
@@ -100,7 +104,7 @@ func FailedWriteHistoryBatchResponse(schemaName string, tableName string, err er
 func FailedDescribeTableResponse(schemaName string, tableName string, err error) *pb.DescribeTableResponse {
 	return &pb.DescribeTableResponse{
 		Response: &pb.DescribeTableResponse_Task{
-			Task: toTask(fmt.Sprintf("Failed to describe table `%s`.`%s`, cause: %s", schemaName, tableName, err)),
+			Task: toTask(addUserReadableHintsToError(fmt.Sprintf("Failed to describe table `%s`.`%s`", schemaName, tableName), err)),
 		},
 	}
 }
@@ -114,7 +118,7 @@ func NotFoundDescribeTableResponse() *pb.DescribeTableResponse {
 func FailedTestResponse(name string, err error) *pb.TestResponse {
 	return &pb.TestResponse{
 		Response: &pb.TestResponse_Failure{
-			Failure: fmt.Sprintf("Test %s failed, cause: %s", name, err),
+			Failure: addUserReadableHintsToError(fmt.Sprintf("Test %s failed", name), err),
 		},
 	}
 }
@@ -122,7 +126,7 @@ func FailedTestResponse(name string, err error) *pb.TestResponse {
 func FailedCreateTableResponse(schemaName string, tableName string, err error) *pb.CreateTableResponse {
 	return &pb.CreateTableResponse{
 		Response: &pb.CreateTableResponse_Task{
-			Task: toTask(fmt.Sprintf("Failed to create table `%s`.`%s`, cause: %s", schemaName, tableName, err)),
+			Task: toTask(addUserReadableHintsToError(fmt.Sprintf("Failed to create table `%s`.`%s`", schemaName, tableName), err)),
 		},
 	}
 }
@@ -130,7 +134,7 @@ func FailedCreateTableResponse(schemaName string, tableName string, err error) *
 func FailedAlterTableResponse(schemaName string, tableName string, err error) *pb.AlterTableResponse {
 	return &pb.AlterTableResponse{
 		Response: &pb.AlterTableResponse_Task{
-			Task: toTask(fmt.Sprintf("Failed to alter table `%s`.`%s`, cause: %s", schemaName, tableName, err)),
+			Task: toTask(addUserReadableHintsToError(fmt.Sprintf("Failed to alter table `%s`.`%s`", schemaName, tableName), err)),
 		},
 	}
 }
@@ -146,7 +150,7 @@ func SuccessfulTruncateTableResponse() *pb.TruncateResponse {
 func FailedTruncateTableResponse(schemaName string, tableName string, err error) *pb.TruncateResponse {
 	return &pb.TruncateResponse{
 		Response: &pb.TruncateResponse_Task{
-			Task: toTask(fmt.Sprintf("Failed to truncate table `%s`.`%s`, cause: %s", schemaName, tableName, err)),
+			Task: toTask(addUserReadableHintsToError(fmt.Sprintf("Failed to truncate table `%s`.`%s`", schemaName, tableName), err)),
 		},
 	}
 }
@@ -155,4 +159,45 @@ func toTask(taskMessage string) *pb.Task {
 	return &pb.Task{
 		Message: taskMessage,
 	}
+}
+
+// ClickHouse server error codes used to translate driver errors into a
+// friendly Task message via addUserReadableHintsToError.
+// Reference: https://github.com/ClickHouse/ClickHouse/blob/master/src/Common/ErrorCodes.cpp
+const (
+	chCodeUnknownTable         = 60
+	chCodeDatabaseDoesNotExist = 81
+	chCodeTimeoutExceeded      = 159
+	chCodeUnknownUser          = 192
+	chCodeSocketTimeout        = 209
+	chCodeNotEnoughPrivileges  = 497
+	chCodeAuthenticationFailed = 516
+)
+
+// addUserReadableHintsToError produces the user-facing Task message that Fivetran:
+//
+//	"<operation>: <friendly message> Technical details: <err>."
+func addUserReadableHintsToError(operation string, err error) string {
+	friendly := "Unexpected error in the ClickHouse destination. Please contact Fivetran support and include the technical details below."
+
+	var ex *clickhouse.Exception
+	switch {
+	case errors.Is(err, context.DeadlineExceeded), errors.Is(err, context.Canceled):
+		friendly = "The ClickHouse operation took too long to complete. Retry the sync. If the problem persists, check the performance of the SQL executed. You may need to optimize batch sizes or scale up the ClickHouse service."
+	case errors.As(err, &ex):
+		switch ex.Code {
+		case chCodeAuthenticationFailed, chCodeUnknownUser:
+			friendly = "ClickHouse rejected the credentials. Verify the username and password configured for the destination."
+		case chCodeNotEnoughPrivileges:
+			friendly = "The ClickHouse user is missing required privileges. Re-run the grants test and apply the privileges listed in the documentation."
+		case chCodeDatabaseDoesNotExist, chCodeUnknownTable:
+			friendly = "The target database or table does not exist in ClickHouse. Verify the schema and table names; the destination will create them on the next sync if needed."
+		case chCodeTimeoutExceeded, chCodeSocketTimeout:
+			friendly = "The ClickHouse query took too long to complete. Retry the sync. If the problem persists, check the performance of the SQL executed. You may need to optimize batch sizes or scale up the ClickHouse service."
+		}
+	case retry.IsNetError(err):
+		friendly = "Could not reach the ClickHouse service. Verify the ClickHouse Cloud service is running and reachable from Fivetran (host, port, IP allowlist)."
+	}
+
+	return fmt.Sprintf("%s: %s Technical details: %s.", operation, friendly, err)
 }

--- a/destination/service/responses_test.go
+++ b/destination/service/responses_test.go
@@ -1,0 +1,113 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"syscall"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddUserReadableHintsToError(t *testing.T) {
+	netErr := &net.OpError{Op: "read", Err: net.UnknownNetworkError("net error")}
+	const op = "Failed to do thing"
+	const unknownMsg = "Unexpected error in the ClickHouse destination. Please contact Fivetran support and include the technical details below."
+
+	tests := []struct {
+		name             string
+		err              error
+		expectedFriendly string
+	}{
+		{
+			name:             "context_deadline",
+			err:              fmt.Errorf("query: %w", context.DeadlineExceeded),
+			expectedFriendly: "The ClickHouse operation took too long to complete. Retry the sync. If the problem persists, check the performance of the SQL executed. You may need to optimize batch sizes or scale up the ClickHouse service.",
+		},
+		{
+			name:             "context_canceled",
+			err:              fmt.Errorf("query: %w", context.Canceled),
+			expectedFriendly: "The ClickHouse operation took too long to complete. Retry the sync. If the problem persists, check the performance of the SQL executed. You may need to optimize batch sizes or scale up the ClickHouse service.",
+		},
+		{
+			name:             "ch_unknown_table",
+			err:              &clickhouse.Exception{Code: 60, Message: "Unknown table"},
+			expectedFriendly: "The target database or table does not exist in ClickHouse. Verify the schema and table names; the destination will create them on the next sync if needed.",
+		},
+		{
+			name:             "ch_database_does_not_exist",
+			err:              &clickhouse.Exception{Code: 81, Message: "Database does not exist"},
+			expectedFriendly: "The target database or table does not exist in ClickHouse. Verify the schema and table names; the destination will create them on the next sync if needed.",
+		},
+		{
+			name:             "ch_timeout_exceeded",
+			err:              &clickhouse.Exception{Code: 159, Message: "Timeout exceeded"},
+			expectedFriendly: "The ClickHouse query took too long to complete. Retry the sync. If the problem persists, check the performance of the SQL executed. You may need to optimize batch sizes or scale up the ClickHouse service.",
+		},
+		{
+			name:             "ch_unknown_user",
+			err:              &clickhouse.Exception{Code: 192, Message: "Unknown user"},
+			expectedFriendly: "ClickHouse rejected the credentials. Verify the username and password configured for the destination.",
+		},
+		{
+			name:             "ch_socket_timeout",
+			err:              &clickhouse.Exception{Code: 209, Message: "Socket timeout"},
+			expectedFriendly: "The ClickHouse query took too long to complete. Retry the sync. If the problem persists, check the performance of the SQL executed. You may need to optimize batch sizes or scale up the ClickHouse service.",
+		},
+		{
+			name:             "ch_not_enough_privileges",
+			err:              &clickhouse.Exception{Code: 497, Message: "Not enough privileges"},
+			expectedFriendly: "The ClickHouse user is missing required privileges. Re-run the grants test and apply the privileges listed in the documentation.",
+		},
+		{
+			name:             "ch_authentication_failed",
+			err:              &clickhouse.Exception{Code: 516, Message: "Authentication failed"},
+			expectedFriendly: "ClickHouse rejected the credentials. Verify the username and password configured for the destination.",
+		},
+		{
+			name:             "ch_exception_wrapped",
+			err:              fmt.Errorf("ExecStatement failed: %w", &clickhouse.Exception{Code: 497, Message: "Not enough privileges"}),
+			expectedFriendly: "The ClickHouse user is missing required privileges. Re-run the grants test and apply the privileges listed in the documentation.",
+		},
+		{
+			name:             "ch_unknown_code_falls_back_to_unknown",
+			err:              &clickhouse.Exception{Code: 99999, Message: "Some new code we have not categorized"},
+			expectedFriendly: unknownMsg,
+		},
+		{
+			name:             "net_op_error",
+			err:              netErr,
+			expectedFriendly: "Could not reach the ClickHouse service. Verify the ClickHouse Cloud service is running and reachable from Fivetran (host, port, IP allowlist).",
+		},
+		{
+			name:             "net_op_error_wrapped",
+			err:              fmt.Errorf("ClickHouse connection error: ping failed after 10 attempts: %w", netErr),
+			expectedFriendly: "Could not reach the ClickHouse service. Verify the ClickHouse Cloud service is running and reachable from Fivetran (host, port, IP allowlist).",
+		},
+		{
+			name:             "io_eof",
+			err:              io.EOF,
+			expectedFriendly: "Could not reach the ClickHouse service. Verify the ClickHouse Cloud service is running and reachable from Fivetran (host, port, IP allowlist).",
+		},
+		{
+			name:             "syscall_econnreset",
+			err:              fmt.Errorf("read: %w", syscall.ECONNRESET),
+			expectedFriendly: "Could not reach the ClickHouse service. Verify the ClickHouse Cloud service is running and reachable from Fivetran (host, port, IP allowlist).",
+		},
+		{
+			name:             "plain_error",
+			err:              errors.New("something blew up"),
+			expectedFriendly: unknownMsg,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			want := fmt.Sprintf("%s: %s Technical details: %s.", op, tc.expectedFriendly, tc.err)
+			assert.Equal(t, want, addUserReadableHintsToError(op, tc.err))
+		})
+	}
+}

--- a/destination/service/responses_test.go
+++ b/destination/service/responses_test.go
@@ -31,7 +31,7 @@ func TestAddUserReadableHintsToError(t *testing.T) {
 		{
 			name:             "context_canceled",
 			err:              fmt.Errorf("query: %w", context.Canceled),
-			expectedFriendly: "The ClickHouse operation took too long to complete. Retry the sync. If the problem persists, check the performance of the SQL executed. You may need to optimize batch sizes or scale up the ClickHouse service.",
+			expectedFriendly: "The operation was cancelled before ClickHouse could complete it. Retry the sync.",
 		},
 		{
 			name:             "ch_unknown_table",
@@ -106,7 +106,7 @@ func TestAddUserReadableHintsToError(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			want := fmt.Sprintf("%s: %s Technical details: %s.", op, tc.expectedFriendly, tc.err)
+			want := fmt.Sprintf("%s: %s Technical details: %s", op, tc.expectedFriendly, tc.err)
 			assert.Equal(t, want, addUserReadableHintsToError(op, tc.err))
 		})
 	}


### PR DESCRIPTION
## Summary
We send tech errors back to Fivetran and these only contain internal information. We should add some user-friendly information that can be actionable by users. Adding a few messages to common errors
