### PR TITLE
Parse UnixTimestamp64Nano instead of leaving it as a string

### DIFF
--- a/destination/common/flags/flags.go
+++ b/destination/common/flags/flags.go
@@ -39,7 +39,7 @@ var SelectBatchSizeSetting = ConfigDefinition{
 var SelectBatchSize = SelectBatchSizeSetting.RegisterFlag()
 
 var MutationBatchSizeSetting = ConfigDefinition{
-	Name: "mutation_batch_size", DefaultValue: 1_500, MinValue: 200, MaxValue: 1_500,
+	Name: "mutation_batch_size", DefaultValue: 1_000, MinValue: 200, MaxValue: 1_000,
 	Description: "Batch size for ALTER TABLE UPDATE mutations (builds SQL strings, keep low to avoid large queries)"}
 var MutationBatchSize = MutationBatchSizeSetting.RegisterFlag()
 

--- a/destination/db/config/config.go
+++ b/destination/db/config/config.go
@@ -80,15 +80,14 @@ func validatePort(port string) (uint, error) {
 
 // ParseAll parses both the connection config and the optional advanced config
 // from the Fivetran configuration map. If destination configurations are present,
-// they are validated and applied to the global flags.
+// they are applied to the global flags (clamped into range with a warning rather
+// than rejected).
 func ParseAll(configuration map[string]string) (*Config, error) {
 	advancedCfg, err := ParseAdvancedConfig(configuration)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse advanced config: %w", err)
 	}
-	if err := ValidateAndOverwriteFlags(advancedCfg.DestinationConfigurations); err != nil {
-		return nil, fmt.Errorf("invalid destination configurations: %w", err)
-	}
+	ValidateAndOverwriteFlags(advancedCfg.DestinationConfigurations)
 	jsonBytes, _ := json.Marshal(advancedCfg)
 	log.Info(fmt.Sprintf("Destination configurations applied: %s", string(jsonBytes)))
 	return Parse(configuration)
@@ -147,34 +146,33 @@ func warnOnUnknownFields(jsonBytes []byte) {
 
 // ValidateAndOverwriteFlags overrides the global flag values with values from the
 // parsed DestinationConfigurations. Nil fields are left at their flag defaults.
-// Returns an error if any value is outside its allowed range.
-func ValidateAndOverwriteFlags(ds *DestinationConfigurations) error {
+// Values outside the allowed range for each setting are clamped to the nearest
+// bound (with a warning logged) rather than rejected, so a stale or aggressive
+// advanced_config never breaks startup.
+func ValidateAndOverwriteFlags(ds *DestinationConfigurations) {
 	if ds == nil {
-		return nil
+		return
 	}
-	if err := applySetting(&flags.WriteBatchSizeSetting, ds.WriteBatchSize); err != nil {
-		return err
-	}
-	if err := applySetting(&flags.SelectBatchSizeSetting, ds.SelectBatchSize); err != nil {
-		return err
-	}
-	if err := applySetting(&flags.MutationBatchSizeSetting, ds.MutationBatchSize); err != nil {
-		return err
-	}
-	if err := applySetting(&flags.HardDeleteBatchSizeSetting, ds.HardDeleteBatchSize); err != nil {
-		return err
-	}
-	return nil
+	applySetting(&flags.WriteBatchSizeSetting, ds.WriteBatchSize)
+	applySetting(&flags.SelectBatchSizeSetting, ds.SelectBatchSize)
+	applySetting(&flags.MutationBatchSizeSetting, ds.MutationBatchSize)
+	applySetting(&flags.HardDeleteBatchSizeSetting, ds.HardDeleteBatchSize)
 }
 
-func applySetting(setting *flags.ConfigDefinition, val *uint) error {
+func applySetting(setting *flags.ConfigDefinition, val *uint) {
 	if val == nil {
 		*setting.Flag = setting.DefaultValue
-		return nil
+		return
 	}
-	if *val < setting.MinValue || *val > setting.MaxValue {
-		return fmt.Errorf("%s: value %d out of allowed range [%d, %d]", setting.Name, *val, setting.MinValue, setting.MaxValue)
+	if *val < setting.MinValue {
+		log.Warn(fmt.Sprintf("%s: value %d is below minimum %d; clamping to %d", setting.Name, *val, setting.MinValue, setting.MinValue))
+		*setting.Flag = setting.MinValue
+		return
+	}
+	if *val > setting.MaxValue {
+		log.Warn(fmt.Sprintf("%s: value %d exceeds maximum %d; clamping to %d", setting.Name, *val, setting.MaxValue, setting.MaxValue))
+		*setting.Flag = setting.MaxValue
+		return
 	}
 	*setting.Flag = *val
-	return nil
 }

--- a/destination/db/config/config_test.go
+++ b/destination/db/config/config_test.go
@@ -261,7 +261,7 @@ func TestParseAdvancedConfigFloatValue(t *testing.T) {
 
 func TestValidateAndOverwriteFlagsNilLeftsFlagsUnchanged(t *testing.T) {
 	originalWriteBatch := *flags.WriteBatchSize
-	assert.NoError(t, ValidateAndOverwriteFlags(nil))
+	ValidateAndOverwriteFlags(nil)
 	assert.Equal(t, originalWriteBatch, *flags.WriteBatchSize)
 }
 
@@ -288,7 +288,7 @@ func TestValidateAndOverwriteFlagsOverridesFlags(t *testing.T) {
 		MutationBatchSize:   &mutationBatch,
 		HardDeleteBatchSize: &hardDelete,
 	}
-	assert.NoError(t, ValidateAndOverwriteFlags(ds))
+	ValidateAndOverwriteFlags(ds)
 
 	assert.Equal(t, writeBatch, *flags.WriteBatchSize)
 	assert.Equal(t, selectBatch, *flags.SelectBatchSize)
@@ -308,7 +308,7 @@ func TestValidateAndOverwriteFlagsPartialOverride(t *testing.T) {
 	ds := &DestinationConfigurations{
 		WriteBatchSize: &writeBatch,
 	}
-	assert.NoError(t, ValidateAndOverwriteFlags(ds))
+	ValidateAndOverwriteFlags(ds)
 
 	assert.Equal(t, writeBatch, *flags.WriteBatchSize)
 	assert.Equal(t, flags.SelectBatchSizeSetting.DefaultValue, *flags.SelectBatchSize)
@@ -316,14 +316,36 @@ func TestValidateAndOverwriteFlagsPartialOverride(t *testing.T) {
 
 func uintPtr(v uint) *uint { return &v }
 
-func TestValidateAndOverwriteFlagsRejectsOutOfRange(t *testing.T) {
+func TestValidateAndOverwriteFlagsClampsOutOfRange(t *testing.T) {
+	originalWriteBatch := *flags.WriteBatchSize
+	originalSelectBatch := *flags.SelectBatchSize
+	originalMutationBatch := *flags.MutationBatchSize
+	originalHardDeleteBatch := *flags.HardDeleteBatchSize
+	defer func() {
+		*flags.WriteBatchSize = originalWriteBatch
+		*flags.SelectBatchSize = originalSelectBatch
+		*flags.MutationBatchSize = originalMutationBatch
+		*flags.HardDeleteBatchSize = originalHardDeleteBatch
+	}()
+
 	belowMin := flags.WriteBatchSizeSetting.MinValue - 1
-	err := ValidateAndOverwriteFlags(&DestinationConfigurations{WriteBatchSize: &belowMin})
-	assert.ErrorContains(t, err, "out of allowed range")
+	ValidateAndOverwriteFlags(&DestinationConfigurations{WriteBatchSize: &belowMin})
+	assert.Equal(t, flags.WriteBatchSizeSetting.MinValue, *flags.WriteBatchSize)
 
 	aboveMax := flags.WriteBatchSizeSetting.MaxValue + 1
-	err = ValidateAndOverwriteFlags(&DestinationConfigurations{WriteBatchSize: &aboveMax})
-	assert.ErrorContains(t, err, "out of allowed range")
+	ValidateAndOverwriteFlags(&DestinationConfigurations{WriteBatchSize: &aboveMax})
+	assert.Equal(t, flags.WriteBatchSizeSetting.MaxValue, *flags.WriteBatchSize)
+
+	// Legacy MutationBatchSize values above the (lowered) ceiling clamp down rather
+	// than breaking startup, so existing advanced_config from before the cap change
+	// keeps working.
+	legacyMutation := uint(1_500)
+	ValidateAndOverwriteFlags(&DestinationConfigurations{MutationBatchSize: &legacyMutation})
+	assert.Equal(t, flags.MutationBatchSizeSetting.MaxValue, *flags.MutationBatchSize)
+
+	zero := uint(0)
+	ValidateAndOverwriteFlags(&DestinationConfigurations{HardDeleteBatchSize: &zero})
+	assert.Equal(t, flags.HardDeleteBatchSizeSetting.MinValue, *flags.HardDeleteBatchSize)
 }
 
 func TestValidateAndOverwriteFlagsAcceptsBoundaryValues(t *testing.T) {
@@ -341,31 +363,10 @@ func TestValidateAndOverwriteFlagsAcceptsBoundaryValues(t *testing.T) {
 		SelectBatchSize:     uintPtr(flags.SelectBatchSizeSetting.MaxValue),
 		HardDeleteBatchSize: uintPtr(flags.HardDeleteBatchSizeSetting.MaxValue),
 	}
-	assert.NoError(t, ValidateAndOverwriteFlags(ds))
+	ValidateAndOverwriteFlags(ds)
 	assert.Equal(t, flags.WriteBatchSizeSetting.MinValue, *flags.WriteBatchSize)
 	assert.Equal(t, flags.SelectBatchSizeSetting.MaxValue, *flags.SelectBatchSize)
 	assert.Equal(t, flags.HardDeleteBatchSizeSetting.MaxValue, *flags.HardDeleteBatchSize)
-}
-
-func TestValidateAndOverwriteFlagsDoesNotModifyFlagsOnError(t *testing.T) {
-	originalWriteBatch := *flags.WriteBatchSize
-	originalSelectBatch := *flags.SelectBatchSize
-	defer func() {
-		*flags.WriteBatchSize = originalWriteBatch
-		*flags.SelectBatchSize = originalSelectBatch
-	}()
-
-	validWrite := flags.WriteBatchSizeSetting.MinValue + 1
-	invalidSelect := flags.SelectBatchSizeSetting.MaxValue + 1
-	ds := &DestinationConfigurations{
-		WriteBatchSize:  &validWrite,
-		SelectBatchSize: &invalidSelect,
-	}
-	err := ValidateAndOverwriteFlags(ds)
-	assert.Error(t, err)
-
-	assert.Equal(t, validWrite, *flags.WriteBatchSize)
-	assert.Equal(t, originalSelectBatch, *flags.SelectBatchSize)
 }
 
 // --- ParseAll tests ---
@@ -423,15 +424,18 @@ func TestParseAllInvalidAdvancedConfigJSON(t *testing.T) {
 	assert.ErrorContains(t, err, "failed to parse advanced config")
 }
 
-func TestParseAllOutOfRangeFlag(t *testing.T) {
+func TestParseAllClampsOutOfRangeFlag(t *testing.T) {
+	originalWriteBatch := *flags.WriteBatchSize
+	defer func() { *flags.WriteBatchSize = originalWriteBatch }()
+
 	input := configWithAdvancedJSON(
 		map[string]string{"host": "my.host"},
 		`{"destination_configurations": {"write_batch_size": 1}}`,
 	)
 	cfg, err := ParseAll(input)
-	assert.Nil(t, cfg)
-	assert.ErrorContains(t, err, "invalid destination configurations")
-	assert.ErrorContains(t, err, "out of allowed range")
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
+	assert.Equal(t, flags.WriteBatchSizeSetting.MinValue, *flags.WriteBatchSize)
 }
 
 func TestParseAllInvalidConnectionConfig(t *testing.T) {

--- a/destination/db/sql/sql.go
+++ b/destination/db/sql/sql.go
@@ -357,9 +357,9 @@ func GetHardDeleteStatement(
 // GetHardDeleteWithTimestampStatement generates statements such as:
 //
 //	DELETE FROM `foo`.`bar` WHERE
-//	    (`id` = 1 AND `_fivetran_start` >= parseDateTime64BestEffort('2022-03-05T04:45:12.123456789Z', 9, 'UTC'))
-//	    OR (`id` = 2 AND `_fivetran_start` >= parseDateTime64BestEffort('2022-03-05T04:45:12.123456789Z', 9, 'UTC'))
-//	    OR (`id` = 3 AND `_fivetran_start` >= parseDateTime64BestEffort('2022-03-05T04:45:12.123456789Z', 9, 'UTC'))
+//	    (`id` = 1 AND `_fivetran_start` >= toDateTime64('2022-03-05T04:45:12.123456789',9,'UTC'))
+//	    OR (`id` = 2 AND `_fivetran_start` >= toDateTime64('2023-04-06T12:30:00.234567890',9,'UTC'))
+//	    OR (`id` = 3 AND `_fivetran_start` >= toDateTime64('2023-04-06T13:00:00.345678901',9,'UTC'))
 //
 // This function combines primary key equality checks with a timestamp comparison for each row,
 // matching the behavior of the Java writeDelete method which uses AND conditions between
@@ -403,6 +403,11 @@ func GetHardDeleteWithTimestampStatement(
 
 		// Build primary key equality conditions with AND between them
 		for _, col := range csvColumns.PrimaryKeys {
+			// timestampColumn is emitted once below as `>=`, so don't repeat it as `=` here.
+			// See: https://github.com/fivetran/fivetran_partner_sdk/blob/3037ce4e941af0226bbe3c2de8068f9a7af7c199/how-to-handle-history-mode-batch-files.md#earliest_start_files
+			if col.Name == timestampColumn {
+				continue
+			}
 			if col.Index >= uint(len(csvRow)) {
 				return "", fmt.Errorf("can't find matching value for primary key with index %d", col.Index)
 			}
@@ -442,9 +447,9 @@ func GetHardDeleteWithTimestampStatement(
 //	UPDATE
 //	    `_fivetran_active` = FALSE,
 //	    `_fivetran_end` = CASE
-//	        WHEN `id` = 1 THEN parseDateTime64BestEffort('2022-03-05T04:45:12.123456788Z', 9, 'UTC')
-//	        WHEN `id` = 2 THEN parseDateTime64BestEffort('2022-03-05T04:45:12.123456789Z', 9, 'UTC')
-//	        WHEN `id` = 3 THEN parseDateTime64BestEffort('2022-03-05T04:45:12.123456789Z', 9, 'UTC')
+//	        WHEN `id` = 1 THEN toDateTime64('2022-03-05T04:45:12.123456788',9,'UTC')
+//	        WHEN `id` = 2 THEN toDateTime64('2023-04-06T12:30:00.234567889',9,'UTC')
+//	        WHEN `id` = 3 THEN toDateTime64('2023-04-06T13:00:00.345678900',9,'UTC')
 //	    END
 //	WHERE `id` IN (1, 2, 3)
 //	    AND `_fivetran_active` = TRUE

--- a/destination/db/sql/sql.go
+++ b/destination/db/sql/sql.go
@@ -357,9 +357,9 @@ func GetHardDeleteStatement(
 // GetHardDeleteWithTimestampStatement generates statements such as:
 //
 //	DELETE FROM `foo`.`bar` WHERE
-//	    (`id` = 1 AND `_fivetran_start` >= '1646455512123456789')
-//	    OR (`id` = 2 AND `_fivetran_start` >= '1680784200234567890')
-//	    OR (`id` = 3 AND `_fivetran_start` >= '1680784300234567890')
+//	    (`id` = 1 AND `_fivetran_start` >= fromUnixTimestamp64Nano(1646455512123456789, 'UTC'))
+//	    OR (`id` = 2 AND `_fivetran_start` >= fromUnixTimestamp64Nano(1680784200234567890, 'UTC'))
+//	    OR (`id` = 3 AND `_fivetran_start` >= fromUnixTimestamp64Nano(1680784300234567890, 'UTC'))
 //
 // This function combines primary key equality checks with a timestamp comparison for each row,
 // matching the behavior of the Java writeDelete method which uses AND conditions between
@@ -442,9 +442,9 @@ func GetHardDeleteWithTimestampStatement(
 //	UPDATE
 //	    `_fivetran_active` = FALSE,
 //	    `_fivetran_end` = CASE
-//	        WHEN `id` = 1 THEN '1646455512123456788'
-//	        WHEN `id` = 2 THEN '1680784200234567889'
-//	        WHEN `id` = 3 THEN '1680786000345678900'
+//	        WHEN `id` = 1 THEN fromUnixTimestamp64Nano(1646455512123456788, 'UTC')
+//	        WHEN `id` = 2 THEN fromUnixTimestamp64Nano(1680784200234567889, 'UTC')
+//	        WHEN `id` = 3 THEN fromUnixTimestamp64Nano(1680786000345678900, 'UTC')
 //	    END
 //	WHERE `id` IN (1, 2, 3)
 //	    AND `_fivetran_active` = TRUE

--- a/destination/db/sql/sql.go
+++ b/destination/db/sql/sql.go
@@ -357,9 +357,9 @@ func GetHardDeleteStatement(
 // GetHardDeleteWithTimestampStatement generates statements such as:
 //
 //	DELETE FROM `foo`.`bar` WHERE
-//	    (`id` = 1 AND `_fivetran_start` >= fromUnixTimestamp64Nano(1646455512123456789, 'UTC'))
-//	    OR (`id` = 2 AND `_fivetran_start` >= fromUnixTimestamp64Nano(1680784200234567890, 'UTC'))
-//	    OR (`id` = 3 AND `_fivetran_start` >= fromUnixTimestamp64Nano(1680784300234567890, 'UTC'))
+//	    (`id` = 1 AND `_fivetran_start` >= parseDateTime64BestEffort('2022-03-05T04:45:12.123456789Z', 9, 'UTC'))
+//	    OR (`id` = 2 AND `_fivetran_start` >= parseDateTime64BestEffort('2022-03-05T04:45:12.123456789Z', 9, 'UTC'))
+//	    OR (`id` = 3 AND `_fivetran_start` >= parseDateTime64BestEffort('2022-03-05T04:45:12.123456789Z', 9, 'UTC'))
 //
 // This function combines primary key equality checks with a timestamp comparison for each row,
 // matching the behavior of the Java writeDelete method which uses AND conditions between
@@ -442,9 +442,9 @@ func GetHardDeleteWithTimestampStatement(
 //	UPDATE
 //	    `_fivetran_active` = FALSE,
 //	    `_fivetran_end` = CASE
-//	        WHEN `id` = 1 THEN fromUnixTimestamp64Nano(1646455512123456788, 'UTC')
-//	        WHEN `id` = 2 THEN fromUnixTimestamp64Nano(1680784200234567889, 'UTC')
-//	        WHEN `id` = 3 THEN fromUnixTimestamp64Nano(1680786000345678900, 'UTC')
+//	        WHEN `id` = 1 THEN parseDateTime64BestEffort('2022-03-05T04:45:12.123456788Z', 9, 'UTC')
+//	        WHEN `id` = 2 THEN parseDateTime64BestEffort('2022-03-05T04:45:12.123456789Z', 9, 'UTC')
+//	        WHEN `id` = 3 THEN parseDateTime64BestEffort('2022-03-05T04:45:12.123456789Z', 9, 'UTC')
 //	    END
 //	WHERE `id` IN (1, 2, 3)
 //	    AND `_fivetran_active` = TRUE

--- a/destination/db/sql/sql_test.go
+++ b/destination/db/sql/sql_test.go
@@ -410,7 +410,7 @@ func TestGetHardDeleteStatement(t *testing.T) {
 	}, fullTableName)
 	assert.NoError(t, err)
 	// DateTime64(9, 'UTC') is converted to nanoseconds.
-	assert.Equal(t, "DELETE FROM `foo`.`bar` WHERE(`ts`)IN((parseDateTime64BestEffort('2022-03-05T04:45:12.123456789Z', 9, 'UTC')),(parseDateTime64BestEffort('2022-03-05T04:45:12.123456789Z', 9, 'UTC')))", statement)
+	assert.Equal(t, "DELETE FROM `foo`.`bar` WHERE(`ts`)IN((parseDateTime64BestEffort('2022-03-05T04:45:12.123456789Z', 9, 'UTC')),(parseDateTime64BestEffort('2023-04-06T12:30:00.234567890Z', 9, 'UTC')))", statement)
 }
 
 func TestGetAllReplicasActiveQuery(t *testing.T) {

--- a/destination/db/sql/sql_test.go
+++ b/destination/db/sql/sql_test.go
@@ -299,7 +299,7 @@ func TestGetSelectByPrimaryKeysQuery(t *testing.T) {
 	}, fullTableName, false)
 	assert.NoError(t, err)
 	// DateTime64(9, 'UTC') is converted to nanoseconds.
-	assert.Equal(t, "SELECT * FROM `foo`.`bar` FINAL WHERE(`ts`)IN((fromUnixTimestamp64Nano(1646455512123456789, 'UTC')),(fromUnixTimestamp64Nano(1680784200234567890, 'UTC')))ORDER BY(`ts`)LIMIT 2", statement)
+	assert.Equal(t, "SELECT * FROM `foo`.`bar` FINAL WHERE(`ts`)IN((parseDateTime64BestEffort('2022-03-05T04:45:12.123456789Z', 9, 'UTC')),(parseDateTime64BestEffort('2023-04-06T12:30:00.234567890Z', 9, 'UTC')))ORDER BY(`ts`)LIMIT 2", statement)
 }
 
 func TestGetCheckDatabaseExistsStatement(t *testing.T) {
@@ -410,7 +410,7 @@ func TestGetHardDeleteStatement(t *testing.T) {
 	}, fullTableName)
 	assert.NoError(t, err)
 	// DateTime64(9, 'UTC') is converted to nanoseconds.
-	assert.Equal(t, "DELETE FROM `foo`.`bar` WHERE(`ts`)IN((fromUnixTimestamp64Nano(1646455512123456789, 'UTC')),(fromUnixTimestamp64Nano(1680784200234567890, 'UTC')))", statement)
+	assert.Equal(t, "DELETE FROM `foo`.`bar` WHERE(`ts`)IN((parseDateTime64BestEffort('2022-03-05T04:45:12.123456789Z', 9, 'UTC')),(parseDateTime64BestEffort('2022-03-05T04:45:12.123456789Z', 9, 'UTC')))", statement)
 }
 
 func TestGetAllReplicasActiveQuery(t *testing.T) {

--- a/destination/db/sql/sql_test.go
+++ b/destination/db/sql/sql_test.go
@@ -299,7 +299,7 @@ func TestGetSelectByPrimaryKeysQuery(t *testing.T) {
 	}, fullTableName, false)
 	assert.NoError(t, err)
 	// DateTime64(9, 'UTC') is converted to nanoseconds.
-	assert.Equal(t, "SELECT * FROM `foo`.`bar` FINAL WHERE(`ts`)IN(('1646455512123456789'),('1680784200234567890'))ORDER BY(`ts`)LIMIT 2", statement)
+	assert.Equal(t, "SELECT * FROM `foo`.`bar` FINAL WHERE(`ts`)IN((fromUnixTimestamp64Nano(1646455512123456789, 'UTC')),(fromUnixTimestamp64Nano(1680784200234567890, 'UTC')))ORDER BY(`ts`)LIMIT 2", statement)
 }
 
 func TestGetCheckDatabaseExistsStatement(t *testing.T) {
@@ -410,7 +410,7 @@ func TestGetHardDeleteStatement(t *testing.T) {
 	}, fullTableName)
 	assert.NoError(t, err)
 	// DateTime64(9, 'UTC') is converted to nanoseconds.
-	assert.Equal(t, "DELETE FROM `foo`.`bar` WHERE(`ts`)IN(('1646455512123456789'),('1680784200234567890'))", statement)
+	assert.Equal(t, "DELETE FROM `foo`.`bar` WHERE(`ts`)IN((fromUnixTimestamp64Nano(1646455512123456789, 'UTC')),(fromUnixTimestamp64Nano(1680784200234567890, 'UTC')))", statement)
 }
 
 func TestGetAllReplicasActiveQuery(t *testing.T) {

--- a/destination/db/sql/sql_test.go
+++ b/destination/db/sql/sql_test.go
@@ -298,8 +298,8 @@ func TestGetSelectByPrimaryKeysQuery(t *testing.T) {
 			{Index: 2, Name: "ts", Type: pb.DataType_UTC_DATETIME, IsPrimaryKey: true}},
 	}, fullTableName, false)
 	assert.NoError(t, err)
-	// DateTime64(9, 'UTC') is converted to nanoseconds.
-	assert.Equal(t, "SELECT * FROM `foo`.`bar` FINAL WHERE(`ts`)IN((parseDateTime64BestEffort('2022-03-05T04:45:12.123456789Z', 9, 'UTC')),(parseDateTime64BestEffort('2023-04-06T12:30:00.234567890Z', 9, 'UTC')))ORDER BY(`ts`)LIMIT 2", statement)
+	// DateTime64(9, 'UTC') values are emitted via toDateTime64 with the ISO timestamp (Z stripped).
+	assert.Equal(t, "SELECT * FROM `foo`.`bar` FINAL WHERE(`ts`)IN((toDateTime64('2022-03-05T04:45:12.123456789',9,'UTC')),(toDateTime64('2023-04-06T12:30:00.234567890',9,'UTC')))ORDER BY(`ts`)LIMIT 2", statement)
 }
 
 func TestGetCheckDatabaseExistsStatement(t *testing.T) {
@@ -409,8 +409,77 @@ func TestGetHardDeleteStatement(t *testing.T) {
 			{Index: 2, Name: "ts", Type: pb.DataType_UTC_DATETIME, IsPrimaryKey: true}},
 	}, fullTableName)
 	assert.NoError(t, err)
-	// DateTime64(9, 'UTC') is converted to nanoseconds.
-	assert.Equal(t, "DELETE FROM `foo`.`bar` WHERE(`ts`)IN((parseDateTime64BestEffort('2022-03-05T04:45:12.123456789Z', 9, 'UTC')),(parseDateTime64BestEffort('2023-04-06T12:30:00.234567890Z', 9, 'UTC')))", statement)
+	// DateTime64(9, 'UTC') values are emitted via toDateTime64 with the ISO timestamp (Z stripped).
+	assert.Equal(t, "DELETE FROM `foo`.`bar` WHERE(`ts`)IN((toDateTime64('2022-03-05T04:45:12.123456789',9,'UTC')),(toDateTime64('2023-04-06T12:30:00.234567890',9,'UTC')))", statement)
+}
+
+func TestGetHardDeleteWithTimestampStatement(t *testing.T) {
+	fullTableName := QualifiedTableName("`foo`.`bar`")
+
+	// Single user-PK + _fivetran_start (history mode). _fivetran_start must appear
+	// only once per row as the `>=` filter, NOT also as a `=` equality (that would
+	// turn a range filter into an exact-match and double the SQL size).
+	csvCols := &types.CSVColumns{
+		All: []*types.CSVColumn{
+			{Index: 0, Name: "id", Type: pb.DataType_LONG, IsPrimaryKey: true},
+			{Index: 1, Name: "name", Type: pb.DataType_STRING},
+			{Index: 2, Name: "_fivetran_start", Type: pb.DataType_UTC_DATETIME, IsPrimaryKey: true},
+		},
+		PrimaryKeys: []*types.CSVColumn{
+			{Index: 0, Name: "id", Type: pb.DataType_LONG, IsPrimaryKey: true},
+			{Index: 2, Name: "_fivetran_start", Type: pb.DataType_UTC_DATETIME, IsPrimaryKey: true},
+		},
+	}
+	batch := [][]string{
+		{"42", "foo", "2022-03-05T04:45:12.123456789Z"},
+		{"43", "bar", "2023-04-06T12:30:00.234567890Z"},
+	}
+
+	statement, err := GetHardDeleteWithTimestampStatement(batch, csvCols, fullTableName, "_fivetran_start", 2, pb.DataType_UTC_DATETIME)
+	assert.NoError(t, err)
+	assert.Equal(t,
+		"DELETE FROM `foo`.`bar` WHERE"+
+			"(`id`=42 AND`_fivetran_start`>=toDateTime64('2022-03-05T04:45:12.123456789',9,'UTC'))OR"+
+			"(`id`=43 AND`_fivetran_start`>=toDateTime64('2023-04-06T12:30:00.234567890',9,'UTC'))",
+		statement)
+
+	// Composite user PKs + _fivetran_start: only the user PKs should appear as `=`,
+	// and _fivetran_start should only appear once per row as `>=`.
+	compositeCSVCols := &types.CSVColumns{
+		All: []*types.CSVColumn{
+			{Index: 0, Name: "id", Type: pb.DataType_LONG, IsPrimaryKey: true},
+			{Index: 1, Name: "name", Type: pb.DataType_STRING, IsPrimaryKey: true},
+			{Index: 2, Name: "_fivetran_start", Type: pb.DataType_UTC_DATETIME, IsPrimaryKey: true},
+		},
+		PrimaryKeys: []*types.CSVColumn{
+			{Index: 0, Name: "id", Type: pb.DataType_LONG, IsPrimaryKey: true},
+			{Index: 1, Name: "name", Type: pb.DataType_STRING, IsPrimaryKey: true},
+			{Index: 2, Name: "_fivetran_start", Type: pb.DataType_UTC_DATETIME, IsPrimaryKey: true},
+		},
+	}
+	statement, err = GetHardDeleteWithTimestampStatement(batch, compositeCSVCols, fullTableName, "_fivetran_start", 2, pb.DataType_UTC_DATETIME)
+	assert.NoError(t, err)
+	assert.Equal(t,
+		"DELETE FROM `foo`.`bar` WHERE"+
+			"(`id`=42 AND`name`='foo' AND`_fivetran_start`>=toDateTime64('2022-03-05T04:45:12.123456789',9,'UTC'))OR"+
+			"(`id`=43 AND`name`='bar' AND`_fivetran_start`>=toDateTime64('2023-04-06T12:30:00.234567890',9,'UTC'))",
+		statement)
+
+	// Validation errors.
+	_, err = GetHardDeleteWithTimestampStatement(batch, csvCols, "", "_fivetran_start", 2, pb.DataType_UTC_DATETIME)
+	assert.ErrorContains(t, err, "table name is empty")
+
+	_, err = GetHardDeleteWithTimestampStatement([][]string{}, csvCols, fullTableName, "_fivetran_start", 2, pb.DataType_UTC_DATETIME)
+	assert.ErrorContains(t, err, "expected non-empty CSV slice")
+
+	_, err = GetHardDeleteWithTimestampStatement(batch, &types.CSVColumns{}, fullTableName, "_fivetran_start", 2, pb.DataType_UTC_DATETIME)
+	assert.ErrorContains(t, err, "expected non-empty primary keys")
+
+	_, err = GetHardDeleteWithTimestampStatement(batch, csvCols, fullTableName, "", 2, pb.DataType_UTC_DATETIME)
+	assert.ErrorContains(t, err, "timestamp column name is empty")
+
+	_, err = GetHardDeleteWithTimestampStatement(batch, csvCols, fullTableName, "_fivetran_start", 99, pb.DataType_UTC_DATETIME)
+	assert.ErrorContains(t, err, "can't find matching value for timestamp column with index 99")
 }
 
 func TestGetAllReplicasActiveQuery(t *testing.T) {

--- a/destination/db/values/values.go
+++ b/destination/db/values/values.go
@@ -34,11 +34,7 @@ func Value(colType pb.DataType, value string) (string, error) {
 		return fmt.Sprintf("'%s'", value), nil
 	// keep these values as DateTime64(9, 'UTC') as defined in constants.DateTimeUTC
 	case pb.DataType_UTC_DATETIME:
-		utcDateTime, err := time.Parse(constants.UTCDateTimeFormat, value)
-		if err != nil {
-			return "", fmt.Errorf("can't parse value %s as UTC datetime: %w", value, err)
-		}
-		return fmt.Sprintf("fromUnixTimestamp64Nano(%d, 'UTC')", utcDateTime.UnixNano()), nil
+		return fmt.Sprintf("parseDateTime64BestEffort('%s', 9, 'UTC')", value), nil
 	default:
 		return value, nil
 	}

--- a/destination/db/values/values.go
+++ b/destination/db/values/values.go
@@ -32,13 +32,13 @@ func Value(colType pb.DataType, value string) (string, error) {
 		pb.DataType_XML,
 		pb.DataType_JSON:
 		return fmt.Sprintf("'%s'", value), nil
-	// specify DateTime64(9) as nanos instead
+	// keep these values as DateTime64(9, 'UTC') as defined in constants.DateTimeUTC
 	case pb.DataType_UTC_DATETIME:
 		utcDateTime, err := time.Parse(constants.UTCDateTimeFormat, value)
 		if err != nil {
 			return "", fmt.Errorf("can't parse value %s as UTC datetime: %w", value, err)
 		}
-		return fmt.Sprintf("'%d'", utcDateTime.UnixNano()), nil
+		return fmt.Sprintf("fromUnixTimestamp64Nano(%d, 'UTC')", utcDateTime.UnixNano()), nil
 	default:
 		return value, nil
 	}

--- a/destination/db/values/values.go
+++ b/destination/db/values/values.go
@@ -3,6 +3,7 @@ package values
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"fivetran.com/fivetran_sdk/destination/common/constants"
@@ -32,9 +33,12 @@ func Value(colType pb.DataType, value string) (string, error) {
 		pb.DataType_XML,
 		pb.DataType_JSON:
 		return fmt.Sprintf("'%s'", value), nil
-	// keep these values as DateTime64(9, 'UTC') as defined in constants.DateTimeUTC
+	// keep these values as DateTime64(9, 'UTC') as defined in constants.DateTimeUTC.
+	// The trailing 'Z' from Fivetran's ISO 8601 format (constants.UTCDateTimeFormat) is
+	// stripped because some toDateTime64 rejects it.
 	case pb.DataType_UTC_DATETIME:
-		return fmt.Sprintf("parseDateTime64BestEffort('%s', 9, 'UTC')", value), nil
+		trimmed := strings.TrimSuffix(value, "Z")
+		return fmt.Sprintf("toDateTime64('%s',9,'UTC')", trimmed), nil
 	default:
 		return value, nil
 	}

--- a/destination/db/values/values_test.go
+++ b/destination/db/values/values_test.go
@@ -52,10 +52,6 @@ func TestQuoteUTCDateTime(t *testing.T) {
 	result, err = Value(pb.DataType_UTC_DATETIME, "2022-03-05T04:45:12Z")
 	assert.NoError(t, err)
 	assert.Equal(t, "parseDateTime64BestEffort('2022-03-05T04:45:12Z', 9, 'UTC')", result)
-
-	result, err = Value(pb.DataType_UTC_DATETIME, "foobar")
-	assert.ErrorContains(t, err, "can't parse value foobar as UTC datetime")
-	assert.Equal(t, "", result)
 }
 
 func TestParseValue(t *testing.T) {

--- a/destination/db/values/values_test.go
+++ b/destination/db/values/values_test.go
@@ -39,19 +39,19 @@ func TestQuoteValue(t *testing.T) {
 func TestQuoteUTCDateTime(t *testing.T) {
 	result, err := Value(pb.DataType_UTC_DATETIME, "2022-03-05T04:45:12.123456789Z")
 	assert.NoError(t, err)
-	assert.Equal(t, "parseDateTime64BestEffort('2022-03-05T04:45:12.123456789Z', 9, 'UTC')", result)
+	assert.Equal(t, "toDateTime64('2022-03-05T04:45:12.123456789',9,'UTC')", result)
 
 	result, err = Value(pb.DataType_UTC_DATETIME, "2022-03-05T04:45:12.123456Z")
 	assert.NoError(t, err)
-	assert.Equal(t, "parseDateTime64BestEffort('2022-03-05T04:45:12.123456Z', 9, 'UTC')", result)
+	assert.Equal(t, "toDateTime64('2022-03-05T04:45:12.123456',9,'UTC')", result)
 
 	result, err = Value(pb.DataType_UTC_DATETIME, "2022-03-05T04:45:12.123Z")
 	assert.NoError(t, err)
-	assert.Equal(t, "parseDateTime64BestEffort('2022-03-05T04:45:12.123Z', 9, 'UTC')", result)
+	assert.Equal(t, "toDateTime64('2022-03-05T04:45:12.123',9,'UTC')", result)
 
 	result, err = Value(pb.DataType_UTC_DATETIME, "2022-03-05T04:45:12Z")
 	assert.NoError(t, err)
-	assert.Equal(t, "parseDateTime64BestEffort('2022-03-05T04:45:12Z', 9, 'UTC')", result)
+	assert.Equal(t, "toDateTime64('2022-03-05T04:45:12',9,'UTC')", result)
 }
 
 func TestParseValue(t *testing.T) {

--- a/destination/db/values/values_test.go
+++ b/destination/db/values/values_test.go
@@ -39,19 +39,19 @@ func TestQuoteValue(t *testing.T) {
 func TestQuoteUTCDateTime(t *testing.T) {
 	result, err := Value(pb.DataType_UTC_DATETIME, "2022-03-05T04:45:12.123456789Z")
 	assert.NoError(t, err)
-	assert.Equal(t, "'1646455512123456789'", result)
+	assert.Equal(t, "fromUnixTimestamp64Nano(1646455512123456789, 'UTC')", result)
 
 	result, err = Value(pb.DataType_UTC_DATETIME, "2022-03-05T04:45:12.123456Z")
 	assert.NoError(t, err)
-	assert.Equal(t, "'1646455512123456000'", result)
+	assert.Equal(t, "fromUnixTimestamp64Nano(1646455512123456000, 'UTC')", result)
 
 	result, err = Value(pb.DataType_UTC_DATETIME, "2022-03-05T04:45:12.123Z")
 	assert.NoError(t, err)
-	assert.Equal(t, "'1646455512123000000'", result)
+	assert.Equal(t, "fromUnixTimestamp64Nano(1646455512123000000, 'UTC')", result)
 
 	result, err = Value(pb.DataType_UTC_DATETIME, "2022-03-05T04:45:12Z")
 	assert.NoError(t, err)
-	assert.Equal(t, "'1646455512000000000'", result)
+	assert.Equal(t, "fromUnixTimestamp64Nano(1646455512000000000, 'UTC')", result)
 
 	result, err = Value(pb.DataType_UTC_DATETIME, "foobar")
 	assert.ErrorContains(t, err, "can't parse value foobar as UTC datetime")

--- a/destination/db/values/values_test.go
+++ b/destination/db/values/values_test.go
@@ -39,19 +39,19 @@ func TestQuoteValue(t *testing.T) {
 func TestQuoteUTCDateTime(t *testing.T) {
 	result, err := Value(pb.DataType_UTC_DATETIME, "2022-03-05T04:45:12.123456789Z")
 	assert.NoError(t, err)
-	assert.Equal(t, "fromUnixTimestamp64Nano(1646455512123456789, 'UTC')", result)
+	assert.Equal(t, "parseDateTime64BestEffort('2022-03-05T04:45:12.123456789Z', 9, 'UTC')", result)
 
 	result, err = Value(pb.DataType_UTC_DATETIME, "2022-03-05T04:45:12.123456Z")
 	assert.NoError(t, err)
-	assert.Equal(t, "fromUnixTimestamp64Nano(1646455512123456000, 'UTC')", result)
+	assert.Equal(t, "parseDateTime64BestEffort('2022-03-05T04:45:12.123456Z', 9, 'UTC')", result)
 
 	result, err = Value(pb.DataType_UTC_DATETIME, "2022-03-05T04:45:12.123Z")
 	assert.NoError(t, err)
-	assert.Equal(t, "fromUnixTimestamp64Nano(1646455512123000000, 'UTC')", result)
+	assert.Equal(t, "parseDateTime64BestEffort('2022-03-05T04:45:12.123Z', 9, 'UTC')", result)
 
 	result, err = Value(pb.DataType_UTC_DATETIME, "2022-03-05T04:45:12Z")
 	assert.NoError(t, err)
-	assert.Equal(t, "fromUnixTimestamp64Nano(1646455512000000000, 'UTC')", result)
+	assert.Equal(t, "parseDateTime64BestEffort('2022-03-05T04:45:12Z', 9, 'UTC')", result)
 
 	result, err = Value(pb.DataType_UTC_DATETIME, "foobar")
 	assert.ErrorContains(t, err, "can't parse value foobar as UTC datetime")

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -122,11 +122,11 @@ These configurations affect how the connector processes data before sending it t
 |---------|------|---------|---------------|-------------|
 | `write_batch_size` | integer | `100000` | 5,000 – 100,000 | Number of rows per batch for insert, update, and replace operations. |
 | `select_batch_size` | integer | `1500` | 200 – 1,500 | Number of rows per batch for SELECT queries used during updates. |
-| `mutation_batch_size` | integer | `1500` | 200 – 1,500 | Number of rows per batch for ALTER TABLE UPDATE mutations in history mode. Lower it if you are experiencing large SQL statements. |
+| `mutation_batch_size` | integer | `1000` | 200 – 1,000 | Number of rows per batch for ALTER TABLE UPDATE mutations in history mode. Lower it if you are experiencing large SQL statements. |
 | `hard_delete_batch_size` | integer | `1500` | 200 – 1,500 | Number of rows per batch for hard delete operations in history mode. Lower it if you are experiencing large SQL statements. |
 
 All fields are optional. If a field is not specified, the default value is used.
-If a value is outside the allowed range, the destination will report an error during sync.
+Values outside the allowed range are clamped to the nearest bound (a warning is logged) rather than rejected, so a stale or aggressive `advanced_config` never breaks startup.
 Unknown fields are silently ignored (a warning is logged) and do not cause errors, which allows forward compatibility when new settings are added.
 
 Example:


### PR DESCRIPTION
## Ongoing PR, not finished yet
All the fix I found for this parsing issue increases the size of the SQL generated and so, increases the risk of SQL errors related to queries being too big.

I have tried removing some extra redundant parts, but it's not enough and the complete PR adds pressure to the SQL size generated.

I think we are losing to much time here. We should just generate the SQL dinamically adding rows until it reaches a maximun size, enough to leave some space to add the comments we add in each query. That way we get rid of the configs and of the risk of users still having issues because of particular tables with a lot of primary key columns.

Next thing to do here: remove the configs (make sure it doesn´t break current configs) and make the SQL generation dinamic.

## Summary
Problem found in this ci job https://github.com/ClickHouse/clickhouse-fivetran-destination/actions/runs/25796014979/job/75773394256

26.5 has made strict how unix timestamp with nano seconds are parsed and now integer with 19 digits (the ones used here) are not allowed.

Error in 26.5 :
```sql

SELECT
    version(),
    '1762808230000000000' AS future_date,
    fromUnixTimestamp64Nano(1762808220000000000) AS past_date,
    future_date > past_date

Query id: 67a633bd-3547-4b07-836c-83fd88f8c895


Elapsed: 0.035 sec.

Received exception from server (version 26.5.1):
Code: 41. DB::Exception: Received from localhost:9000. DB::Exception: Cannot read DateTime: unexpected number of decimal digits: 19: while converting '1762808230000000000' to DateTime64(9): In scope SELECT version(), '1762808230000000000' AS future_date, fromUnixTimestamp64Nano(1762808220000000000) AS past_date, future_date > past_date. (CANNOT_PARSE_DATETIME)
```
Working in 26.4:
```sql
SELECT
    version(),
    '1762808230000000000' AS future_date,
    fromUnixTimestamp64Nano(1762808220000000000) AS past_date,
    future_date > past_date

Query id: a4d1468c-bb1d-49ee-8721-6f054c634e0f

   ┌─version()─┬─future_date─────────┬─────────────────────past_date─┬─greater(futu⋯ past_date)─┐
1. │ 26.4.2.10 │ 1762808230000000000 │ 2025-11-10 20:57:00.000000000 │                        1 │
   └───────────┴─────────────────────┴───────────────────────────────┴──────────────────────────┘

1 row in set. Elapsed: 0.003 sec.
```

I'm not 100% sure about what changed, but looks like they used to use a int64 comparator for these digits and DateTime64(9) and now they are using the internal DateTime64 comparator which is more strict on the values allowed.

**The fix:** instead of relying on the internal string/int64 -> date, let's just pass the value as it's and parse it to `DateTime64(9, 'UTC')` which is the one expecting to have by using the `parseDateTime64BestEffort('{value}, 9, 'UTC')` function

Alternatives explored:
- `UnixTimestamp64Nano(timestamp_generated_in_go)`: makes sense, but then, what's the point of transforming the string to timestamp in go, to then transform the timestamp to datetime64 in CH? we can just transform the string to datetime64 and avoid that extra jump.
- `parseDateTime64BestEffort('{value}, 9, 'UTC')` can manage the string as it's, but now we have another issue: now the sql we generate is way bigger. We went from 21 charts to 69, more than triple, and this will reach the limits of the sql we added in flags.go.


