### PR TITLE
Update pending docs to point to clickhouse docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,7 +125,7 @@ For each issue, provide: file and line reference, rationale, and a suggested fix
 - Backwards-compatible change?
 - Existing tests still pass?
 - New tests added for new behavior?
-- Documentation updated if user-facing behavior changed? Canonical user-facing docs live in the clickhouse-docs repo under `docs/integrations/data-ingestion/etl-tools/fivetran/` (see also the the [technical reference](https://clickhouse.com/docs/integrations/fivetran/reference) and [troubleshooting & best practices](https://clickhouse.com/docs/integrations/fivetran/troubleshooting) pages).
+- Documentation updated if user-facing behavior changed? Canonical user-facing docs live in the clickhouse-docs repo under `docs/integrations/data-ingestion/etl-tools/fivetran/` (see also the [technical reference](https://clickhouse.com/docs/integrations/fivetran/reference) and [troubleshooting & best practices](https://clickhouse.com/docs/integrations/fivetran/troubleshooting) pages).
 
 ## Documentation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,11 +125,11 @@ For each issue, provide: file and line reference, rationale, and a suggested fix
 - Backwards-compatible change?
 - Existing tests still pass?
 - New tests added for new behavior?
-- Documentation updated if user-facing behavior changed? (see [docs/overview.md](./docs/overview.md) and [docs/schema_operations.md](./docs/schema_operations.md))
+- Documentation updated if user-facing behavior changed? Canonical user-facing docs live in the clickhouse-docs repo under `docs/integrations/data-ingestion/etl-tools/fivetran/` (see also the the [technical reference](https://clickhouse.com/docs/integrations/fivetran/reference) and [troubleshooting & best practices](https://clickhouse.com/docs/integrations/fivetran/troubleshooting) pages).
 
 ## Documentation
 
-User-facing documentation lives in `docs/`. When changing behavior that affects data type mappings, table structure, sync modes, or migration operations, update the relevant docs. The PR template includes a checklist item for this.
+Canonical user-facing documentation lives in the [clickhouse-docs repo](https://github.com/ClickHouse/clickhouse-docs) under `docs/integrations/data-ingestion/etl-tools/fivetran/` (`index.md`, `reference.md`, `troubleshooting.md`). When changing behavior that affects data type mappings, table structure, sync modes, or migration operations, update those files. The local `docs/` folder in this repo hosts the Fivetran-side overview and setup guide (published at fivetran.com/docs). The PR template includes a checklist item for documentation updates.
 
 ## MCP servers
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,13 @@ Currently, supports [ClickHouse Cloud](https://clickhouse.cloud) only.
 
 ## Documentation
 
-- [Overview](https://fivetran.com/docs/destinations/clickhouse)
-- [Setup guide](https://fivetran.com/docs/destinations/clickhouse/setup-guide)
+- ClickHouse-side docs:
+  - [Fivetran and ClickHouse Cloud — overview](https://clickhouse.com/docs/integrations/fivetran)
+  - [Technical reference](https://clickhouse.com/docs/integrations/fivetran/reference)
+  - [Troubleshooting & best practices](https://clickhouse.com/docs/integrations/fivetran/troubleshooting)
+- Fivetran-side docs:
+  - [Destination overview](https://fivetran.com/docs/destinations/clickhouse)
+  - [Setup guide](https://fivetran.com/docs/destinations/clickhouse/setup-guide)
 
 ## Contributing
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -13,6 +13,9 @@ in [ClickHouse Cloud](https://clickhouse.cloud).
 > NOTE: This destination is [partner-built](/docs/partner-built-program). For any questions related to ClickHouse Cloud
 > destination and its documentation, contact [ClickHouse Cloud Support](mailto:support@clickhouse.com).
 
+> See also: [the Fivetran docs in the ClickHouse documentation](https://clickhouse.com/docs/integrations/fivetran)
+> for the most up-to-date type mappings, table structures, history mode details, and troubleshooting tips.
+
 ----
 
 {% partial file="destinations/saas-supported-deployment-models.template.md" /%}

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -94,55 +94,7 @@ level.
 
 ## Advanced Configuration
 
-The ClickHouse Cloud destination supports an optional JSON configuration file for advanced use cases. This file allows you to fine-tune destination behavior by overriding the default settings that control batch sizes, parallelism, connection pools, and request timeouts.
-
-> NOTE: This configuration is entirely optional. If no file is uploaded, the destination uses
-> sensible defaults that work well for most use cases.
-
----
-
-### Uploading the configuration file
-
-The file must be valid JSON and conform to the schema described below.
-
-If you need to modify the configuration after the initial setup, you can edit the destination configurations in the Fivetran dashboard and upload an updated file.
-
-The configuration file has a top-level section:
-
-```json
-{
-  "destination_configurations": { ... }
-}
-```
-
-Inside of it you can specify the following configurations that control the internal behavior of the ClickHouse destination connector itself.
-These configurations affect how the connector processes data before sending it to ClickHouse.
-
-| Setting | Type | Default | Allowed Range | Description |
-|---------|------|---------|---------------|-------------|
-| `write_batch_size` | integer | `100000` | 5,000 – 100,000 | Number of rows per batch for insert, update, and replace operations. |
-| `select_batch_size` | integer | `1500` | 200 – 1,500 | Number of rows per batch for SELECT queries used during updates. |
-| `mutation_batch_size` | integer | `1500` | 200 – 1,500 | Number of rows per batch for ALTER TABLE UPDATE mutations in history mode. Lower it if you are experiencing large SQL statements. |
-| `hard_delete_batch_size` | integer | `1500` | 200 – 1,500 | Number of rows per batch for hard delete operations in history mode. Lower it if you are experiencing large SQL statements. |
-
-All fields are optional. If a field is not specified, the default value is used.
-If a value is outside the allowed range, the destination will report an error during sync.
-Unknown fields are silently ignored (a warning is logged) and do not cause errors, which allows forward compatibility when new settings are added.
-
-Example:
-
-```json
-{
-  "destination_configurations": {
-    "write_batch_size": 50000,
-    "select_batch_size": 200
-  }
-}
-```
-
----
-
-### Limitations
-
-- The configuration file applies to all syncs for the destination. It cannot vary per sync or per connector.
-- The maximum file size allowed for the configuration file is 1 MB.
+The ClickHouse Cloud destination supports an optional JSON configuration file to fine-tune batch sizes
+and other internal behavior. See the
+[ClickHouse documentation — advanced configuration](https://clickhouse.com/docs/integrations/fivetran/reference#advanced-configuration)
+for the schema, defaults, allowed ranges, and examples.


### PR DESCRIPTION
Pending changes to make Fivetran's docs point to ClickHouse docs site