### PR TITLE
Fix string escaping when creating sql

### DIFF
--- a/destination/db/sql/sql.go
+++ b/destination/db/sql/sql.go
@@ -712,18 +712,8 @@ func GetLocalMutationsCompletedQuery(schemaName string, tableName string) (strin
 	}
 	return fmt.Sprintf(
 		"SELECT toBool(count(*) = 0) FROM system.mutations WHERE database = %s AND table = %s AND is_done = 0",
-		singleQuoted(schemaName), singleQuoted(tableName),
+		values.QuoteAndEscapeString(schemaName), values.QuoteAndEscapeString(tableName),
 	), nil
-}
-
-// escapeSQLString escapes single quotes in a string for use in SQL literals.
-func escapeSQLString(s string) string {
-	return strings.ReplaceAll(s, "'", "''")
-}
-
-// singleQuoted wraps a string in single quotes with escaping for SQL string literals.
-func singleQuoted(s string) string {
-	return fmt.Sprintf("'%s'", escapeSQLString(s))
 }
 
 func identifier(s string) string {

--- a/destination/db/sql/sql.go
+++ b/destination/db/sql/sql.go
@@ -700,22 +700,6 @@ func GetRenameTableStatement(
 		fromTableIdentifier, toTableIdentifier), nil
 }
 
-// GetLocalMutationsCompletedQuery generates a query to check if all mutations on a table are complete.
-// Unlike GetAllMutationsCompletedQuery, this queries system.mutations directly (no clusterAllReplicas)
-// and works on both local Docker ClickHouse and ClickHouse Cloud.
-func GetLocalMutationsCompletedQuery(schemaName string, tableName string) (string, error) {
-	if tableName == "" {
-		return "", fmt.Errorf("table name is empty")
-	}
-	if schemaName == "" {
-		return "", fmt.Errorf("schema name for table %s is empty", tableName)
-	}
-	return fmt.Sprintf(
-		"SELECT toBool(count(*) = 0) FROM system.mutations WHERE database = %s AND table = %s AND is_done = 0",
-		values.QuoteAndEscapeString(schemaName), values.QuoteAndEscapeString(tableName),
-	), nil
-}
-
 func identifier(s string) string {
 	return fmt.Sprintf("`%s`", s)
 }

--- a/destination/db/sql/sql_migrate_test.go
+++ b/destination/db/sql/sql_migrate_test.go
@@ -199,7 +199,7 @@ func TestGetUpdateColumnValueStatementSpecialChars(t *testing.T) {
 	// Backslash in value
 	stmt, err = GetUpdateColumnValueStatement("s", "t", "col", values.NewMigrateValueQuoted("path\\to\\file"))
 	assert.NoError(t, err)
-	assert.Equal(t, "ALTER TABLE `s`.`t` UPDATE `col` = 'path\\to\\file' WHERE true", stmt)
+	assert.Equal(t, "ALTER TABLE `s`.`t` UPDATE `col` = 'path\\\\to\\\\file' WHERE true", stmt)
 
 	// Empty string value (not null)
 	stmt, err = GetUpdateColumnValueStatement("s", "t", "col", values.NewMigrateValueQuoted(""))

--- a/destination/db/sql/sql_test.go
+++ b/destination/db/sql/sql_test.go
@@ -521,10 +521,3 @@ func TestGetLocalMutationsCompletedQuery(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "SELECT toBool(count(*) = 0) FROM system.mutations WHERE database = 'test''db' AND table = 'test''table' AND is_done = 0", query)
 }
-
-func TestEscapeSQLString(t *testing.T) {
-	assert.Equal(t, "hello", escapeSQLString("hello"))
-	assert.Equal(t, "O''Brien", escapeSQLString("O'Brien"))
-	assert.Equal(t, "it''s a ''test''", escapeSQLString("it's a 'test'"))
-	assert.Equal(t, "", escapeSQLString(""))
-}

--- a/destination/db/sql/sql_test.go
+++ b/destination/db/sql/sql_test.go
@@ -504,20 +504,3 @@ func TestGetRenameTablesStatementErrors(t *testing.T) {
 	_, err = GetRenameTableStatement("", "table", "new")
 	assert.ErrorContains(t, err, "schema name for tables table/new is empty")
 }
-
-func TestGetLocalMutationsCompletedQuery(t *testing.T) {
-	query, err := GetLocalMutationsCompletedQuery("foo", "bar")
-	assert.NoError(t, err)
-	assert.Equal(t, "SELECT toBool(count(*) = 0) FROM system.mutations WHERE database = 'foo' AND table = 'bar' AND is_done = 0", query)
-
-	_, err = GetLocalMutationsCompletedQuery("", "bar")
-	assert.ErrorContains(t, err, "schema name for table bar is empty")
-
-	_, err = GetLocalMutationsCompletedQuery("foo", "")
-	assert.ErrorContains(t, err, "table name is empty")
-
-	// Test SQL escaping of schema/table names with single quotes
-	query, err = GetLocalMutationsCompletedQuery("test'db", "test'table")
-	assert.NoError(t, err)
-	assert.Equal(t, "SELECT toBool(count(*) = 0) FROM system.mutations WHERE database = 'test''db' AND table = 'test''table' AND is_done = 0", query)
-}

--- a/destination/db/values/values.go
+++ b/destination/db/values/values.go
@@ -23,10 +23,6 @@ var MaxDateTime64Nanos = strconv.FormatInt(MaxDateTime64.UnixNano(), 10)
 // Value formats a CSV-sourced value into a SQL literal for the write path.
 // Paired with NewMigrateValue (migration path); the two must agree on the
 // effective literal produced for a given (DataType, value).
-//
-// Contract: Value quotes but does NOT escape embedded single quotes — safe
-// because CSV-sourced data never contains raw ones. NewMigrateValue does
-// escape, because SDK default values are user-configurable.
 func Value(colType pb.DataType, value string) (string, error) {
 	switch colType {
 	case // quote types that we can pass as a string
@@ -39,7 +35,7 @@ func Value(colType pb.DataType, value string) (string, error) {
 		pb.DataType_BINARY,
 		pb.DataType_XML,
 		pb.DataType_JSON:
-		return fmt.Sprintf("'%s'", value), nil
+		return QuoteAndEscapeString(value), nil
 	// specify DateTime64(9) as nanos instead
 	case pb.DataType_UTC_DATETIME:
 		utcDateTime, err := time.Parse(constants.UTCDateTimeFormat, value)
@@ -65,14 +61,17 @@ func NewMigrateValueNull() MigrateValue {
 	return MigrateValue{literal: "NULL", isNull: true}
 }
 
-// NewMigrateValueQuoted single-quotes value and escapes any embedded quotes
-// (SQL-standard doubling). Use this when there is no DataType to work with,
+// NewMigrateValueQuoted single-quotes value and escapes it for use inside a
+// ClickHouse string literal. Use this when there is no DataType to work with,
 // or when the type-aware conversion has already happened.
 func NewMigrateValueQuoted(value string) MigrateValue {
-	// Inlined rather than reusing sql.escapeSQLString: values → sql would
-	// cycle (sql already imports values for MaxDateTime64Nanos).
-	escaped := strings.ReplaceAll(value, "'", "''")
-	return MigrateValue{literal: fmt.Sprintf("'%s'", escaped)}
+	return MigrateValue{literal: QuoteAndEscapeString(value)}
+}
+
+var sqlStringEscaper = strings.NewReplacer(`\`, `\\`, `'`, `''`)
+
+func QuoteAndEscapeString(value string) string {
+	return "'" + sqlStringEscaper.Replace(value) + "'"
 }
 
 // IsNull reports whether the value is SQL NULL.

--- a/destination/db/values/values.go
+++ b/destination/db/values/values.go
@@ -70,6 +70,8 @@ func NewMigrateValueQuoted(value string) MigrateValue {
 
 var sqlStringEscaper = strings.NewReplacer(`\`, `\\`, `'`, `''`)
 
+// QuoteAndEscapeString wraps value in single quotes and escapes it for safe
+// use inside a ClickHouse SQL string literal.
 func QuoteAndEscapeString(value string) string {
 	return "'" + sqlStringEscaper.Replace(value) + "'"
 }

--- a/destination/db/values/values_test.go
+++ b/destination/db/values/values_test.go
@@ -37,6 +37,20 @@ func TestQuoteValue(t *testing.T) {
 	}
 }
 
+func TestQuoteAndEscapeString(t *testing.T) {
+	assert.Equal(t, "'hello'", QuoteAndEscapeString("hello"))
+	assert.Equal(t, "''", QuoteAndEscapeString(""))
+	// Single quotes are SQL-standard doubled.
+	assert.Equal(t, "'O''Brien'", QuoteAndEscapeString("O'Brien"))
+	assert.Equal(t, "'it''s a ''test'''", QuoteAndEscapeString("it's a 'test'"))
+	assert.Equal(t, `'{"branchName":"s-later-then-w2''s-year"}'`, QuoteAndEscapeString(`{"branchName":"s-later-then-w2's-year"}`))
+	// Backslashes are doubled (ClickHouse treats backslash as an escape char), so
+	// the literal round-trips back to the original value instead of being corrupted.
+	assert.Equal(t, `'a\\nb'`, QuoteAndEscapeString(`a\nb`))
+	assert.Equal(t, `'trailing\\'`, QuoteAndEscapeString(`trailing\`))
+	assert.Equal(t, `'a\\''b'`, QuoteAndEscapeString(`a\'b`))
+}
+
 func TestQuoteUTCDateTime(t *testing.T) {
 	result, err := Value(pb.DataType_UTC_DATETIME, "2022-03-05T04:45:12.123456789Z")
 	assert.NoError(t, err)

--- a/destination/db/values/values_test.go
+++ b/destination/db/values/values_test.go
@@ -29,6 +29,9 @@ func TestQuoteValue(t *testing.T) {
 		{pb.DataType_JSON, "{\"foo\": \"bar\"}", "'{\"foo\": \"bar\"}'"},
 		{pb.DataType_NAIVE_DATE, "2022-03-05", "'2022-03-05'"},
 		{pb.DataType_NAIVE_DATETIME, "2022-03-05T04:45:12", "'2022-03-05T04:45:12'"},
+		// Make sure the values are escaped (all reamining variations tested in TestQuoteAndEscapeString)
+		{pb.DataType_STRING, "a'b", "'a''b'"},
+		{pb.DataType_STRING, "a\nb", "'a\\nb'"},
 	}
 	for _, arg := range args {
 		result, err := Value(arg.colType, arg.value)

--- a/destination/db/values/values_test.go
+++ b/destination/db/values/values_test.go
@@ -31,7 +31,7 @@ func TestQuoteValue(t *testing.T) {
 		{pb.DataType_NAIVE_DATETIME, "2022-03-05T04:45:12", "'2022-03-05T04:45:12'"},
 		// Make sure the values are escaped (all remaining variations tested in TestQuoteAndEscapeString)
 		{pb.DataType_STRING, "a'b", "'a''b'"},
-		{pb.DataType_STRING, "a\nb", "'a\\nb'"},
+		{pb.DataType_STRING, `a\nb`, `'a\\nb'`},
 	}
 	for _, arg := range args {
 		result, err := Value(arg.colType, arg.value)

--- a/destination/db/values/values_test.go
+++ b/destination/db/values/values_test.go
@@ -29,7 +29,7 @@ func TestQuoteValue(t *testing.T) {
 		{pb.DataType_JSON, "{\"foo\": \"bar\"}", "'{\"foo\": \"bar\"}'"},
 		{pb.DataType_NAIVE_DATE, "2022-03-05", "'2022-03-05'"},
 		{pb.DataType_NAIVE_DATETIME, "2022-03-05T04:45:12", "'2022-03-05T04:45:12'"},
-		// Make sure the values are escaped (all reamining variations tested in TestQuoteAndEscapeString)
+		// Make sure the values are escaped (all remaining variations tested in TestQuoteAndEscapeString)
 		{pb.DataType_STRING, "a'b", "'a''b'"},
 		{pb.DataType_STRING, "a\nb", "'a\\nb'"},
 	}


### PR DESCRIPTION
## Summary
Problem: We were not escaping the strings when creating the SQL to remove rows in some of the operations. So a `'` in the middle of a value would break the SQL causing an error like:

```
Syntax error: failed at position 1423 (s) (line 2, col 1331): xxxx'xxx"}',''), Expected one of: comma or closing bracket, token, Comma, ClosingRoundBracket, OR, AND, IS NOT DISTINCT FROM, IS DISTINCT FROM, IS NULL, IS NOT NULL, BETWEEN, NOT BETWEEN, LIKE, ILIKE, NOT LIKE, NOT ILIKE, REGEXP, IN, NOT IN, GLOBAL IN, GLOBAL NOT IN, MOD, DIV, alias, AS
```

Fix:
- Move escaping logic to a single place (values.go) and include escaping both `\` and `'`
- Use the new logic in all places where it was used before.
- Use it inside the Values function, the place where we found the problem.

Footnote
- We should have probably done this directly using `conn.Exec` with `?` arguments so the clickhouse-go driver will actually do the escaping, but that require a few more changes that will complicate the PR and delay the fix. This PR put the code in a better position to tackle that next time.