### PR TITLE
Reduce memory on insert operations: Remove one of the copies of the batch that we keep in memory

### DIFF
--- a/destination/db/clickhouse.go
+++ b/destination/db/clickhouse.go
@@ -639,7 +639,7 @@ func (conn *ClickHouseConnection) InsertBatch(
 				// Abort releases the batch's connection back to the pool;
 				// batch.Append and batch.Send handle that themselves on failure.
 				_ = batch.Abort()
-				return fmt.Errorf("error converting row for %s: %w", qualifiedTableName, err)
+				return fmt.Errorf("[%s] error converting row for %s: %w", opName, qualifiedTableName, err)
 			}
 			if err := batch.Append(row...); err != nil {
 				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {

--- a/destination/db/clickhouse.go
+++ b/destination/db/clickhouse.go
@@ -603,6 +603,7 @@ func (conn *ClickHouseConnection) DropTable(
 // materializes the transformed set: values are produced one at a time.
 // The result is re-iterable as long as seq is.
 func mapErr[S, T any](seq iter.Seq[S], f func(S) (T, error)) iter.Seq2[T, error] {
+	return func(yield func(T, error) bool) {
 		for v := range seq {
 			if !yield(f(v)) {
 				return
@@ -761,7 +762,7 @@ func (conn *ClickHouseConnection) ReplaceBatch(
 			toInsertRow := func(csvRow []string) ([]any, error) {
 				return ToInsertRow(csvRow, csvColumns, nullStr)
 			}
-			err = conn.InsertBatch(ctx, qualifiedTableName, MapErr(slices.Values(batch), toInsertRow), string(insertBatchReplaceTask))
+			err = conn.InsertBatch(ctx, qualifiedTableName, mapErr(slices.Values(batch), toInsertRow), string(insertBatchReplaceTask))
 			if err != nil {
 				return totalRows, err
 			}

--- a/destination/db/clickhouse.go
+++ b/destination/db/clickhouse.go
@@ -5,6 +5,8 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"iter"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -596,17 +598,34 @@ func (conn *ClickHouseConnection) DropTable(
 	return conn.ExecStatement(ctx, statement, dropTable, false)
 }
 
+// MapErr lazily transforms a sequence with a function that may fail, yielding
+// each transformed value together with its error. Iterating the result never
+// materializes the transformed set: values are produced one at a time.
+// The result is re-iterable as long as seq is.
+func MapErr[S, T any](seq iter.Seq[S], f func(S) (T, error)) iter.Seq2[T, error] {
+	return func(yield func(T, error) bool) {
+		for v := range seq {
+			if !yield(f(v)) {
+				return
+			}
+		}
+	}
+}
+
+// InsertBatch prepares an INSERT batch, appends every row yielded by rows, and
+// sends it, retrying the whole operation on transient errors. A non-nil error
+// yielded by rows (e.g. a CSV conversion failure) aborts the insert.
+//
+// Because the operation is retried, rows may be iterated once per attempt: it
+// MUST be re-iterable, e.g. a lazy transformation over an in-memory slice.
+// Never pass a single-use iterator (such as one consuming a file or network
+// stream) — a retry would silently insert incomplete data.
 func (conn *ClickHouseConnection) InsertBatch(
 	ctx context.Context,
 	qualifiedTableName sql.QualifiedTableName,
-	rows [][]interface{},
-	skipIdx map[int]bool,
+	rows iter.Seq2[[]any, error],
 	opName string,
 ) error {
-	if len(skipIdx) == len(rows) {
-		log.Warn(fmt.Sprintf("[%s] All rows are skipped for %s", opName, qualifiedTableName))
-		return nil
-	}
 	return retry.OnNetError(func() error {
 		batch, err := conn.PrepareBatch(ctx, fmt.Sprintf("INSERT INTO %s", qualifiedTableName))
 		if err != nil {
@@ -616,12 +635,14 @@ func (conn *ClickHouseConnection) InsertBatch(
 			}
 			return fmt.Errorf("error while preparing batch for %s: %w", qualifiedTableName, err)
 		}
-		for i, row := range rows {
-			if skipIdx[i] {
-				continue
-			}
-			err = batch.Append(row...)
+		for row, err := range rows {
 			if err != nil {
+				// Abort releases the batch's connection back to the pool;
+				// batch.Append and batch.Send handle that themselves on failure.
+				_ = batch.Abort()
+				return fmt.Errorf("error converting row for %s: %w", qualifiedTableName, err)
+			}
+			if err := batch.Append(row...); err != nil {
 				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 					// ctx.Err() is diagnostic context, not the primary error; %v is nil-safe.
 					return fmt.Errorf("error appending row to a batch for %s: %w (context state: %v)", qualifiedTableName, err, ctx.Err()) //nolint:errorlint
@@ -738,15 +759,10 @@ func (conn *ClickHouseConnection) ReplaceBatch(
 			}
 			totalRows += len(batch)
 			log.Notice(fmt.Sprintf("[%s] Read batch of %d rows (total so far: %d)", insertBatchReplace, len(batch), totalRows))
-			insertRows := make([][]interface{}, len(batch))
-			for j, csvRow := range batch {
-				insertRow, err := ToInsertRow(csvRow, csvColumns, nullStr)
-				if err != nil {
-					return totalRows, err
-				}
-				insertRows[j] = insertRow
+			toInsertRow := func(csvRow []string) ([]any, error) {
+				return ToInsertRow(csvRow, csvColumns, nullStr)
 			}
-			err = conn.InsertBatch(ctx, qualifiedTableName, insertRows, nil, string(insertBatchReplaceTask))
+			err = conn.InsertBatch(ctx, qualifiedTableName, MapErr(slices.Values(batch), toInsertRow), string(insertBatchReplaceTask))
 			if err != nil {
 				return totalRows, err
 			}
@@ -799,11 +815,16 @@ func (conn *ClickHouseConnection) UpdateBatch(
 			if err != nil {
 				return totalRows, err
 			}
-			insertRows, skipIdx, err := MergeUpdatedRows(batch, selectRows, csvColumns, nullStr, unmodifiedStr, isHistoryMode)
+			insertRows, err := MergeUpdatedRows(batch, selectRows, csvColumns, nullStr, unmodifiedStr, isHistoryMode)
 			if err != nil {
 				return totalRows, err
 			}
-			err = conn.InsertBatch(ctx, qualifiedTableName, insertRows, skipIdx, string(insertBatchUpdateTask))
+			if len(insertRows) == 0 {
+				log.Warn(fmt.Sprintf("[%s] No rows to insert for %s", insertBatchUpdate, qualifiedTableName))
+				continue
+			}
+			noConversion := func(row []any) ([]any, error) { return row, nil }
+			err = conn.InsertBatch(ctx, qualifiedTableName, MapErr(slices.Values(insertRows), noConversion), string(insertBatchUpdateTask))
 			if err != nil {
 				return totalRows, err
 			}

--- a/destination/db/clickhouse.go
+++ b/destination/db/clickhouse.go
@@ -598,12 +598,11 @@ func (conn *ClickHouseConnection) DropTable(
 	return conn.ExecStatement(ctx, statement, dropTable, false)
 }
 
-// MapErr lazily transforms a sequence with a function that may fail, yielding
+// mapErr lazily transforms a sequence with a function that may fail, yielding
 // each transformed value together with its error. Iterating the result never
 // materializes the transformed set: values are produced one at a time.
 // The result is re-iterable as long as seq is.
-func MapErr[S, T any](seq iter.Seq[S], f func(S) (T, error)) iter.Seq2[T, error] {
-	return func(yield func(T, error) bool) {
+func mapErr[S, T any](seq iter.Seq[S], f func(S) (T, error)) iter.Seq2[T, error] {
 		for v := range seq {
 			if !yield(f(v)) {
 				return

--- a/destination/db/clickhouse.go
+++ b/destination/db/clickhouse.go
@@ -823,7 +823,7 @@ func (conn *ClickHouseConnection) UpdateBatch(
 				continue
 			}
 			noConversion := func(row []any) ([]any, error) { return row, nil }
-			err = conn.InsertBatch(ctx, qualifiedTableName, MapErr(slices.Values(insertRows), noConversion), string(insertBatchUpdateTask))
+			err = conn.InsertBatch(ctx, qualifiedTableName, mapErr(slices.Values(insertRows), noConversion), string(insertBatchUpdateTask))
 			if err != nil {
 				return totalRows, err
 			}

--- a/destination/db/clickhouse_integration_test.go
+++ b/destination/db/clickhouse_integration_test.go
@@ -3,12 +3,14 @@ package db
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 
 	"fivetran.com/fivetran_sdk/destination/common/flags"
 	"fivetran.com/fivetran_sdk/destination/common/types"
 	"fivetran.com/fivetran_sdk/destination/db/config"
+	"fivetran.com/fivetran_sdk/destination/db/sql"
 	pb "fivetran.com/fivetran_sdk/proto"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -276,6 +278,61 @@ func TestRenameTableIdempotentOnRetry(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "code: 57")
 	})
+}
+
+func TestInsertBatchAbortsOnConversionError(t *testing.T) {
+	ctx := context.Background()
+	conn := getTestConnection(t, ctx, map[string]string{
+		"host":     "localhost",
+		"port":     "9000",
+		"username": "default",
+		"local":    "true",
+	})
+	defer conn.Close() //nolint:errcheck
+
+	dbName := "fivetran_test"
+	tableName := fmt.Sprintf("test_insert_batch_abort_%s", strings.ReplaceAll(uuid.New().String(), "-", "_"))
+	err := conn.Exec(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", dbName))
+	require.NoError(t, err)
+	err = conn.Exec(ctx, fmt.Sprintf(
+		"CREATE TABLE %s.%s (id Int64, name String) ENGINE = MergeTree ORDER BY id", dbName, tableName))
+	require.NoError(t, err)
+	defer func() {
+		err := conn.Exec(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s.%s", dbName, tableName))
+		assert.NoError(t, err)
+	}()
+
+	qualifiedTableName, err := sql.GetQualifiedTableName(dbName, tableName)
+	require.NoError(t, err)
+
+	countRows := func(t *testing.T) uint64 {
+		t.Helper()
+		row := conn.QueryRow(ctx, fmt.Sprintf("SELECT count() FROM %s.%s", dbName, tableName))
+		var count uint64
+		require.NoError(t, row.Scan(&count))
+		return count
+	}
+
+	// A conversion failure on the second row must abort the whole batch:
+	// the error is surfaced (not retried) and no rows are inserted.
+	failOnSecondRow := func(row []any) ([]any, error) {
+		if row[0].(int64) == 2 {
+			return nil, fmt.Errorf("cannot convert row with id %d", row[0])
+		}
+		return row, nil
+	}
+	rows := [][]any{{int64(1), "one"}, {int64(2), "two"}, {int64(3), "three"}}
+	err = conn.InsertBatch(ctx, qualifiedTableName, mapErr(slices.Values(rows), failOnSecondRow), "TestInsertBatchAbort")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "error converting row for")
+	assert.ErrorContains(t, err, "cannot convert row with id 2")
+	assert.Equal(t, uint64(0), countRows(t))
+
+	// The connection must remain usable after Abort released it.
+	noConversion := func(row []any) ([]any, error) { return row, nil }
+	err = conn.InsertBatch(ctx, qualifiedTableName, mapErr(slices.Values(rows), noConversion), "TestInsertBatchAbort")
+	require.NoError(t, err)
+	assert.Equal(t, uint64(3), countRows(t))
 }
 
 func TestDescribeTable(t *testing.T) {

--- a/destination/db/clickhouse_test.go
+++ b/destination/db/clickhouse_test.go
@@ -1,0 +1,84 @@
+package db
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMapErr(t *testing.T) {
+	errBoom := errors.New("boom")
+	double := func(v int) (int, error) {
+		if v < 0 {
+			return 0, fmt.Errorf("negative value %d: %w", v, errBoom)
+		}
+		return v * 2, nil
+	}
+
+	collect := func(input []int) (values []int, errs []error) {
+		for v, err := range mapErr(slices.Values(input), double) {
+			values = append(values, v)
+			errs = append(errs, err)
+		}
+		return values, errs
+	}
+
+	t.Run("transforms all values in order", func(t *testing.T) {
+		values, errs := collect([]int{1, 2, 3})
+		assert.Equal(t, []int{2, 4, 6}, values)
+		for _, err := range errs {
+			assert.NoError(t, err)
+		}
+	})
+
+	t.Run("empty sequence yields nothing", func(t *testing.T) {
+		values, errs := collect(nil)
+		assert.Empty(t, values)
+		assert.Empty(t, errs)
+	})
+
+	t.Run("yields transform errors alongside values", func(t *testing.T) {
+		values, errs := collect([]int{1, -1, 3})
+		assert.Equal(t, []int{2, 0, 6}, values)
+		require.Len(t, errs, 3)
+		assert.NoError(t, errs[0])
+		assert.ErrorIs(t, errs[1], errBoom)
+		assert.NoError(t, errs[2])
+	})
+
+	t.Run("stops transforming when the consumer breaks", func(t *testing.T) {
+		calls := 0
+		counting := func(v int) (int, error) {
+			calls++
+			return v, nil
+		}
+		for range mapErr(slices.Values([]int{1, 2, 3}), counting) {
+			break
+		}
+		assert.Equal(t, 1, calls, "transform must not run after the consumer stops iterating")
+	})
+
+	t.Run("is re-iterable with identical results", func(t *testing.T) {
+		seq := mapErr(slices.Values([]int{1, 2, 3}), double)
+		first := slices.Collect(func(yield func(int) bool) {
+			for v := range seq {
+				if !yield(v) {
+					return
+				}
+			}
+		})
+		second := slices.Collect(func(yield func(int) bool) {
+			for v := range seq {
+				if !yield(v) {
+					return
+				}
+			}
+		})
+		assert.Equal(t, []int{2, 4, 6}, first)
+		assert.Equal(t, first, second, "sequence must be safe to iterate more than once (retry contract)")
+	})
+}

--- a/destination/db/rows.go
+++ b/destination/db/rows.go
@@ -118,6 +118,7 @@ func GetCSVRowMappingKey(csvRow []string, csvCols *types.CSVColumns, isHistoryMo
 
 // MergeUpdatedRows merges a CSV with existing ClickHouse rows to create a batch of rows to insert back to the database.
 // `selectRows` are fetched from ClickHouse in advance using primary key values from CSV records.
+// CSV rows without a matching table row are logged and left out of the result.
 // See also: ToUpdatedRow.
 func MergeUpdatedRows(
 	csv [][]string,
@@ -126,29 +127,27 @@ func MergeUpdatedRows(
 	nullStr string,
 	unmodifiedStr string,
 	isHistoryMode bool,
-) (insertRows [][]interface{}, skipIdx map[int]bool, err error) {
-	insertRows = make([][]interface{}, len(csv))
-	skipIdx = make(map[int]bool)
-	for j, csvRow := range csv {
+) ([][]any, error) {
+	insertRows := make([][]any, 0, len(csv))
+	for _, csvRow := range csv {
 		mappingKey, err := GetCSVRowMappingKey(csvRow, csvCols, isHistoryMode)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		dbRow, exists := selectRows[mappingKey]
 		if exists {
 			updatedRow, err := ToUpdatedRow(csvRow, dbRow, csvCols, nullStr, unmodifiedStr)
 			if err != nil {
-				return nil, nil, err
+				return nil, err
 			}
-			insertRows[j] = updatedRow
+			insertRows = append(insertRows, updatedRow)
 		} else {
 			// Shouldn't happen
 			log.Warn(fmt.Sprintf("[MergeUpdatedRows] Row with PK mapping %s does not exist", mappingKey))
-			skipIdx[j] = true
 			continue
 		}
 	}
-	return insertRows, skipIdx, nil
+	return insertRows, nil
 }
 
 // ToInsertRow converts a CSV row to a ClickHouse row, parsing strings and converting them to the correct types.


### PR DESCRIPTION
## Summary
Related to https://github.com/ClickHouse/clickhouse-fivetran-destination/issues/107

**Problem**: Syncs on wide tables were hitting the container memory limit (OOM) during WriteBatch. For each insert batch (up to 100k rows), the connector held three full copies in memory at once: 
- The raw CSV rows ([][]string)
- A converted copy with every cell boxed as interface{} ([][]any, typically the largest of the three),
- And the clickhouse-go column block built by batch.Append.

**Solution**: Eliminate the boxed intermediate copy. InsertBatch now takes a lazy row sequence (iter.Seq2[[]any, error]) instead of a materialized slice, and ReplaceBatch converts each CSV row via ToInsertRow on the fly as it's appended to the driver batch — so each converted row is garbage-collectable immediately after Append. Peak memory per batch drops from **raw + boxed + driver block** to **raw + driver block**.

**The raw CSV batch is intentionally kept**: inserts are retried on network errors, so the sequence must be re-iterable (documented on InsertBatch). Conversion errors abort the insert and are not retried, as before. 

As a side simplification, MergeUpdatedRows now returns a compacted slice instead of a slice with holes plus a skipIdx map.

No user-facing changes.

 Follow-ups planned: 
- Set size batches by bytes apart from row count so it's also limited by it.