### PR TITLE
Add AccountName and GroupName to initial query

### DIFF
--- a/.docker/clickhouse/config.xml
+++ b/.docker/clickhouse/config.xml
@@ -47,6 +47,34 @@
         </default>
     </remote_servers>
 
+    <!-- Embedded Keeper and distributed DDL queue, required for
+         ON CLUSTER statements (e.g. SYSTEM FLUSH LOGS ON CLUSTER default)
+         used by tests to reach all replicas in ClickHouse Cloud. -->
+    <keeper_server>
+        <tcp_port>9181</tcp_port>
+        <server_id>1</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>localhost</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+
+    <zookeeper>
+        <node>
+            <host>localhost</host>
+            <port>9181</port>
+        </node>
+    </zookeeper>
+
+    <distributed_ddl>
+        <path>/clickhouse/task_queue/ddl</path>
+    </distributed_ddl>
+
     <!-- required after 25.1+ -->
     <format_schema_path>/var/lib/clickhouse/format_schemas/</format_schema_path>
     <user_directories>

--- a/.docker/clickhouse/config.xml
+++ b/.docker/clickhouse/config.xml
@@ -33,6 +33,20 @@
         <flush_interval_milliseconds>1000</flush_interval_milliseconds>
     </query_log>
 
+    <!-- Single-node "default" cluster, so that queries over
+         clusterAllReplicas(default, ...) used against ClickHouse Cloud
+         also work in local/CI tests. -->
+    <remote_servers>
+        <default>
+            <shard>
+                <replica>
+                    <host>localhost</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </default>
+    </remote_servers>
+
     <!-- required after 25.1+ -->
     <format_schema_path>/var/lib/clickhouse/format_schemas/</format_schema_path>
     <user_directories>

--- a/destination/common/fivetran/metadata.go
+++ b/destination/common/fivetran/metadata.go
@@ -1,0 +1,49 @@
+package fivetran
+
+import (
+	"os"
+	"strings"
+)
+
+// Environment variables with runtime metadata provided by the Fivetran platform, see:
+// https://github.com/fivetran/fivetran_partner_sdk/blob/main/development-guide/development-guide.md#environment-variables
+const (
+	AccountNameEnvVar = "FIVETRAN_ACCOUNT_NAME"
+	GroupNameEnvVar   = "FIVETRAN_GROUP_NAME"
+)
+
+// Metadata contains the Fivetran runtime metadata attributes.
+// Fields are empty when the corresponding environment variables are not set,
+// e.g. when running locally or with the SDK tester.
+type Metadata struct {
+	AccountName string
+	GroupName   string
+}
+
+// GetMetadata reads the Fivetran runtime metadata from the environment.
+func GetMetadata() Metadata {
+	return Metadata{
+		AccountName: sanitize(os.Getenv(AccountNameEnvVar)),
+		GroupName:   sanitize(os.Getenv(GroupNameEnvVar)),
+	}
+}
+
+// String renders the metadata as a comma-separated list of key-value pairs
+// Returns an empty string when no metadata is set.
+func (m Metadata) String() string {
+	var parts []string
+	if m.AccountName != "" {
+		parts = append(parts, "fivetran_account_name: "+m.AccountName)
+	}
+	if m.GroupName != "" {
+		parts = append(parts, "fivetran_group_name: "+m.GroupName)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// sanitize strips line breaks so the value cannot terminate a single-line SQL comment.
+func sanitize(value string) string {
+	value = strings.ReplaceAll(value, "\r", " ")
+	value = strings.ReplaceAll(value, "\n", " ")
+	return strings.TrimSpace(value)
+}

--- a/destination/common/fivetran/metadata_test.go
+++ b/destination/common/fivetran/metadata_test.go
@@ -1,0 +1,74 @@
+package fivetran
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetMetadata(t *testing.T) {
+	tests := []struct {
+		name        string
+		accountName string
+		groupName   string
+		expected    Metadata
+	}{
+		{
+			name:     "no env vars set",
+			expected: Metadata{},
+		},
+		{
+			name:        "both env vars set",
+			accountName: "acme",
+			groupName:   "my_destination",
+			expected:    Metadata{AccountName: "acme", GroupName: "my_destination"},
+		},
+		{
+			name:        "values are trimmed and line breaks are stripped",
+			accountName: "  acme\ncorp\r\n",
+			groupName:   "\tmy_destination ",
+			expected:    Metadata{AccountName: "acme corp", GroupName: "my_destination"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(AccountNameEnvVar, tt.accountName)
+			t.Setenv(GroupNameEnvVar, tt.groupName)
+			assert.Equal(t, tt.expected, GetMetadata())
+		})
+	}
+}
+
+func TestMetadataString(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata Metadata
+		expected string
+	}{
+		{
+			name:     "no metadata",
+			metadata: Metadata{},
+			expected: "",
+		},
+		{
+			name:     "account name only",
+			metadata: Metadata{AccountName: "acme"},
+			expected: "fivetran_account_name: acme",
+		},
+		{
+			name:     "group name only",
+			metadata: Metadata{GroupName: "my_destination"},
+			expected: "fivetran_group_name: my_destination",
+		},
+		{
+			name:     "both fields",
+			metadata: Metadata{AccountName: "acme", GroupName: "my_destination"},
+			expected: "fivetran_account_name: acme, fivetran_group_name: my_destination",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.metadata.String())
+		})
+	}
+}

--- a/destination/db/clickhouse.go
+++ b/destination/db/clickhouse.go
@@ -16,6 +16,7 @@ import (
 	"fivetran.com/fivetran_sdk/destination/common/benchmark"
 	"fivetran.com/fivetran_sdk/destination/common/constants"
 	csvfile "fivetran.com/fivetran_sdk/destination/common/csv"
+	"fivetran.com/fivetran_sdk/destination/common/fivetran"
 	"fivetran.com/fivetran_sdk/destination/common/flags"
 	"fivetran.com/fivetran_sdk/destination/common/log"
 	"fivetran.com/fivetran_sdk/destination/common/retry"
@@ -126,8 +127,15 @@ func GetClickHouseConnection(ctx context.Context, connConfig *config.Config) (*C
 	if err != nil {
 		return nil, fmt.Errorf("ClickHouse connection error: %w", err)
 	}
-	log.Info("ClickHouse connection established successfully")
-	return &ClickHouseConnection{Conn: conn, username: connConfig.Username, isLocal: connConfig.Local}, nil
+	chConn := &ClickHouseConnection{Conn: conn, username: connConfig.Username, isLocal: connConfig.Local}
+	version, err := chConn.GetVersion(ctx)
+	if err != nil {
+		// Non-fatal: the version query is informational and the connection was already verified via Ping.
+		log.Warn(fmt.Sprintf("Failed to query the ClickHouse server version: %v", err))
+		version = "unknown"
+	}
+	log.Info(fmt.Sprintf("ClickHouse connection established successfully, server version: %s", version))
+	return chConn, nil
 }
 
 func (conn *ClickHouseConnection) ExecStatement(
@@ -1160,6 +1168,28 @@ func (conn *ClickHouseConnection) WaitDatabaseIsCreated(
 	return nil
 }
 
+// GetVersion queries the ClickHouse server version. The Fivetran runtime metadata, if available,
+// is included as a SQL comment so it is visible in the ClickHouse query log for supportability.
+func (conn *ClickHouseConnection) GetVersion(ctx context.Context) (string, error) {
+	query := "SELECT version()"
+	if metadata := fivetran.GetMetadata().String(); metadata != "" {
+		query = fmt.Sprintf("-- %s\n%s", metadata, query)
+	}
+	rows, err := conn.ExecQuery(ctx, query, getVersion, false)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close() //nolint:errcheck
+	if !rows.Next() {
+		return "", fmt.Errorf("unexpected empty result from the version query")
+	}
+	var version string
+	if err = rows.Scan(&version); err != nil {
+		return "", err
+	}
+	return version, nil
+}
+
 func (conn *ClickHouseConnection) ConnectionTest(ctx context.Context) error {
 	rows, err := conn.ExecQuery(ctx, "SELECT toInt8(42) AS fivetran_connection_check", connectionTest, false)
 	if err != nil {
@@ -1284,6 +1314,7 @@ const (
 	selectByPrimaryKeys        connectionOpType = "SelectByPrimaryKeys"
 	getUserGrants              connectionOpType = "GetUserGrants"
 	connectionTest             connectionOpType = "ConnectionTest"
+	getVersion                 connectionOpType = "GetVersion"
 	allReplicasActive          connectionOpType = "AllReplicasActive"
 	allMutationsCompleted      connectionOpType = "AllMutationsCompleted"
 	waitDatabaseIsCreated      connectionOpType = "WaitDatabaseIsCreated"

--- a/destination/db/clickhouse_integration_test.go
+++ b/destination/db/clickhouse_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"fivetran.com/fivetran_sdk/destination/common/fivetran"
 	"fivetran.com/fivetran_sdk/destination/common/flags"
 	"fivetran.com/fivetran_sdk/destination/common/types"
 	"fivetran.com/fivetran_sdk/destination/db/config"
@@ -93,6 +94,56 @@ func TestGetVersion(t *testing.T) {
 	version, err := conn.GetVersion(ctx)
 	require.NoError(t, err)
 	assert.NotEmpty(t, version)
+}
+
+func TestGetVersionWithFivetranMetadata(t *testing.T) {
+	// Unique account name so the query can be unambiguously found in system.query_log
+	accountName := fmt.Sprintf("test-account-%s", uuid.New().String())
+	t.Setenv(fivetran.AccountNameEnvVar, accountName)
+	t.Setenv(fivetran.GroupNameEnvVar, "test-group")
+
+	ctx := context.Background()
+	conn := getTestConnection(t, ctx, map[string]string{
+		"host":     "localhost",
+		"port":     "9000",
+		"username": "default",
+		"local":    "true",
+	})
+	defer conn.Close() //nolint:errcheck
+
+	version, err := conn.GetVersion(ctx)
+	require.NoError(t, err)
+	assert.NotEmpty(t, version)
+
+	// Verify the query that reached the server actually contained the metadata comment.
+	err = conn.Exec(ctx, "SYSTEM FLUSH LOGS ON CLUSTER default")
+	require.NoError(t, err)
+	row := conn.QueryRow(ctx,
+		"SELECT query FROM clusterAllReplicas(default, system.query_log) WHERE type = 'QueryFinish' AND query LIKE $1 ORDER BY event_time_microseconds DESC LIMIT 1",
+		"%"+accountName+"%")
+	var loggedQuery string
+	require.NoError(t, row.Scan(&loggedQuery))
+	assert.Contains(t, loggedQuery,
+		fmt.Sprintf("-- fivetran_account_name: %s, fivetran_group_name: test-group", accountName))
+	assert.Contains(t, loggedQuery, "SELECT version()")
+}
+
+func TestGetVersionCancelledContext(t *testing.T) {
+	ctx := context.Background()
+	conn := getTestConnection(t, ctx, map[string]string{
+		"host":     "localhost",
+		"port":     "9000",
+		"username": "default",
+		"local":    "true",
+	})
+	defer conn.Close() //nolint:errcheck
+
+	cancelledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	version, err := conn.GetVersion(cancelledCtx)
+	assert.ErrorContains(t, err, "context canceled")
+	assert.Empty(t, version)
 }
 
 func TestGrants(t *testing.T) {

--- a/destination/db/clickhouse_integration_test.go
+++ b/destination/db/clickhouse_integration_test.go
@@ -80,6 +80,21 @@ func TestConnection(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestGetVersion(t *testing.T) {
+	ctx := context.Background()
+	conn := getTestConnection(t, ctx, map[string]string{
+		"host":     "localhost",
+		"port":     "9000",
+		"username": "default",
+		"local":    "true",
+	})
+	defer conn.Close() //nolint:errcheck
+
+	version, err := conn.GetVersion(ctx)
+	require.NoError(t, err)
+	assert.NotEmpty(t, version)
+}
+
 func TestGrants(t *testing.T) {
 	guid := func() string {
 		return strings.ReplaceAll(uuid.New().String(), "-", "")

--- a/destination/db/clickhouse_integration_test.go
+++ b/destination/db/clickhouse_integration_test.go
@@ -117,7 +117,10 @@ func TestGetVersionWithFivetranMetadata(t *testing.T) {
 	assert.NotEmpty(t, version)
 
 	// Verify the query that reached the server actually contained the metadata comment.
-	err = conn.Exec(ctx, "SYSTEM FLUSH LOGS ON CLUSTER default")
+	// Read the query log on all replicas: in ClickHouse Cloud the version query may have
+	// landed on a different replica than the one serving this connection. SYSTEM FLUSH LOGS
+	// only flushes the current replica, so poll while the others flush on their own interval.
+	err = conn.Exec(ctx, "SYSTEM FLUSH LOGS")
 	require.NoError(t, err)
 	var loggedQuery string
 	require.Eventually(t, func() bool {

--- a/destination/db/clickhouse_integration_test.go
+++ b/destination/db/clickhouse_integration_test.go
@@ -116,11 +116,8 @@ func TestGetVersionWithFivetranMetadata(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, version)
 
-	// Verify the query that reached the server actually contained the metadata comment.
-	// Read the query log on all replicas: in ClickHouse Cloud the version query may have
-	// landed on a different replica than the one serving this connection. SYSTEM FLUSH LOGS
-	// only flushes the current replica, so poll while the others flush on their own interval.
-	err = conn.Exec(ctx, "SYSTEM FLUSH LOGS")
+	// Verify the query that the servers actually contained the metadata comment.
+	err = conn.Exec(ctx, "SYSTEM FLUSH LOGS ON CLUSTER default")
 	require.NoError(t, err)
 	var loggedQuery string
 	require.Eventually(t, func() bool {

--- a/destination/db/clickhouse_integration_test.go
+++ b/destination/db/clickhouse_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"fivetran.com/fivetran_sdk/destination/common/fivetran"
 	"fivetran.com/fivetran_sdk/destination/common/flags"
@@ -116,13 +117,18 @@ func TestGetVersionWithFivetranMetadata(t *testing.T) {
 	assert.NotEmpty(t, version)
 
 	// Verify the query that reached the server actually contained the metadata comment.
-	err = conn.Exec(ctx, "SYSTEM FLUSH LOGS ON CLUSTER default")
+	// Read the query log on all replicas: in ClickHouse Cloud the version query may have
+	// landed on a different replica than the one serving this connection. SYSTEM FLUSH LOGS
+	// only flushes the current replica, so poll while the others flush on their own interval.
+	err = conn.Exec(ctx, "SYSTEM FLUSH LOGS")
 	require.NoError(t, err)
-	row := conn.QueryRow(ctx,
-		"SELECT query FROM clusterAllReplicas(default, system.query_log) WHERE type = 'QueryFinish' AND query LIKE $1 ORDER BY event_time_microseconds DESC LIMIT 1",
-		"%"+accountName+"%")
 	var loggedQuery string
-	require.NoError(t, row.Scan(&loggedQuery))
+	require.Eventually(t, func() bool {
+		row := conn.QueryRow(ctx,
+			"SELECT query FROM clusterAllReplicas(default, system.query_log) WHERE type = 'QueryFinish' AND query LIKE $1 ORDER BY event_time_microseconds DESC LIMIT 1",
+			"%"+accountName+"%")
+		return row.Scan(&loggedQuery) == nil
+	}, 30*time.Second, 500*time.Millisecond, "version query not found in system.query_log on any replica")
 	assert.Contains(t, loggedQuery,
 		fmt.Sprintf("-- fivetran_account_name: %s, fivetran_group_name: test-group", accountName))
 	assert.Contains(t, loggedQuery, "SELECT version()")

--- a/destination/db/clickhouse_integration_test.go
+++ b/destination/db/clickhouse_integration_test.go
@@ -117,10 +117,7 @@ func TestGetVersionWithFivetranMetadata(t *testing.T) {
 	assert.NotEmpty(t, version)
 
 	// Verify the query that reached the server actually contained the metadata comment.
-	// Read the query log on all replicas: in ClickHouse Cloud the version query may have
-	// landed on a different replica than the one serving this connection. SYSTEM FLUSH LOGS
-	// only flushes the current replica, so poll while the others flush on their own interval.
-	err = conn.Exec(ctx, "SYSTEM FLUSH LOGS")
+	err = conn.Exec(ctx, "SYSTEM FLUSH LOGS ON CLUSTER default")
 	require.NoError(t, err)
 	var loggedQuery string
 	require.Eventually(t, func() bool {


### PR DESCRIPTION
## Summary
Fixes https://github.com/ClickHouse/clickhouse-fivetran-destination/issues/69

- Adds the new metadata fields (client and group) if present to a first `select version()` call so it's logged in CH side.
- Adds the version of CH in the logs in the destination side.